### PR TITLE
fix: match editor import wording

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -42,7 +42,7 @@
         <div class="toolbar-right">
           <button class="btn btn-secondary" id="btn-new" title="New filter">New</button>
           <button class="btn btn-secondary" id="btn-import" title="Import .filter file from disk">Import File</button>
-          <button class="btn btn-secondary" id="btn-import-author" title="Import from a community filter author">Import from Author</button>
+          <button class="btn btn-secondary" id="btn-import-author" title="Import from a community filter author">Import from Community Author</button>
           <button class="btn btn-accent" id="btn-wizard" title="Answer questions to build a custom filter">Build My Filter</button>
           <button class="btn btn-primary" id="btn-export" title="Download as .filter file">Export .filter</button>
           <input type="file" id="file-import" accept=".filter,.txt" style="display:none">


### PR DESCRIPTION
## What changed
- Updated the editor toolbar button text from "Import from Author" to "Import from Community Author".

## Why
- The editor popup already used the longer name, so the button now matches it.

## How tested
- Checked the editor HTML.
- Confirmed the button and modal use the same wording.