### PR TITLE
docs: replace duplicate guide link

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -164,7 +164,7 @@ ItemDisplay[RUNE>19]: %GOLD%%RUNENAME% Rune%MAP%%SOUNDID-4718%</code></pre>
           <li><a href="faq.html">FAQ</a> — Answers to common questions and troubleshooting</li>
           <li><a href="https://wiki.projectdiablo2.com/wiki/Item_Filtering" target="_blank" rel="noopener">PD2 Wiki — Syntax Reference</a> — Full documentation of every condition, output, and keyword</li>
           <li><a href="filters.html">Community Filters</a> — Browse filters to use or learn from</li>
-          <li><a href="https://wiki.projectdiablo2.com/wiki/Item_Filtering" target="_blank" rel="noopener">PD2 Wiki</a> — Official item filtering documentation</li>
+          <li><a href="editor.html">Filter Editor</a> — Try editing a filter in the built-in editor</li>
         </ul>
 
         <div class="callout success">


### PR DESCRIPTION
## What changed
- Replaced the duplicate PD2 Wiki link in the guide with a link to the built-in Filter Editor page.

## Why
- The Next Steps list pointed to the same wiki page twice, so one spot was redundant.
- The Filter Editor link gives readers a more useful next step on this site.

## How tested
- Reviewed the guide HTML.
- Confirmed the Next Steps list now has one wiki link and one editor link.