### PR TITLE
docs: clarify FAQ search hint

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -38,7 +38,7 @@
       </div>
 
       <div class="faq-search-wrap">
-        <input type="text" class="search-input" id="faq-search" placeholder="Search FAQ..." autocomplete="off">
+        <input type="text" class="search-input" id="faq-search" placeholder="Search questions, answers, and tags..." autocomplete="off">
       </div>
       <div class="faq-result-count" id="faq-result-count"></div>
 


### PR DESCRIPTION
## What changed
- Updated the FAQ search placeholder to say it searches questions, answers, and tags.

## Why
- The old placeholder was too vague and did not explain what the search box could find.

## How tested
- Reviewed the FAQ page markup.
- Confirmed the search box text now matches the search behavior in the FAQ script.