### PR TITLE
docs: add issue button to docs nav

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -19,6 +19,7 @@
       <li><a href="guide.html">Guide</a></li>
       <li><a href="editor.html">Editor</a></li>
     </ul>
+    <a href="https://github.com/Maaaaaarrk/FilterForge/issues" target="_blank" rel="noopener" class="nav-issue-btn" title="Report an issue">Report Issue</a>
     <button class="nav-hamburger" aria-label="Toggle navigation">&#9776;</button>
   </nav>
 


### PR DESCRIPTION
## What changed
- Added the existing Report Issue nav button to the docs page.

## Why
- The other site pages already offer the same button, but docs did not.
- Adding it keeps the docs page consistent and gives readers a quick way to report broken examples or unclear syntax.

## How tested
- Reviewed the docs HTML.
- Confirmed the nav now matches the existing issue-report pattern used on the other pages.