### PR TITLE
docs: clarify filters search hint

### DIFF
--- a/filters.html
+++ b/filters.html
@@ -39,7 +39,7 @@
       </div>
 
       <div class="faq-search-wrap">
-        <input type="text" class="search-input" id="filter-search" placeholder="Search filters..." autocomplete="off">
+        <input type="text" class="search-input" id="filter-search" placeholder="Search by filter or author..." autocomplete="off">
       </div>
 
       <div class="filter-grid" id="filter-grid"></div>


### PR DESCRIPTION
## What changed
- Updated the filters search placeholder to say it searches by filter name or author.

## Why
- The old placeholder was too vague and did not explain that author names are searchable too.

## How tested
- Reviewed the filters page markup.
- Confirmed the placeholder now matches the search logic in `js/filters.js`.