### PR TITLE
fix: accept short rune codes in preview

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -2010,8 +2010,15 @@
     // Boolean flag
     if (item.flags && item.flags.indexOf(token) !== -1) return true;
 
-    // Item code match (case-insensitive)
-    if (token.toLowerCase() === item.code.toLowerCase()) return true;
+    // Preview rune samples use stackable codes (r30s), but site examples often use r30.
+    // Treat both forms as equivalent so exact rune-code rules preview correctly.
+    var tokenCode = token.toLowerCase();
+    var itemCode = item.code.toLowerCase();
+    if (tokenCode === itemCode) return true;
+    if (item.values && item.values.RUNE > 0) {
+      var shortRuneCode = itemCode.replace(/s$/, '');
+      if (tokenCode === shortRuneCode || tokenCode === shortRuneCode + 's') return true;
+    }
 
     // GOLD special
     if (token === 'GOLD' && item.values && item.values.GOLD > 0) return true;


### PR DESCRIPTION
## What changed
- taught the editor preview matcher to treat short rune codes like `r30` and stackable rune codes like `r30s` as equivalent
- keeps existing `r30s` preview behavior working while fixing exact-rule previews for the short form already shown in the UI and FAQ examples

## Why
- the editor preview teaches users rune codes like `r30`, but the live preview only matched the sample rune item when the rule used `r30s`
- that made exact rune-code rules fall through to later catch-all rules, which is misleading when testing filter logic

## How tested
- opened `editor.html`
- pasted `ItemDisplay[r30]: %RED%Ber Rune%BORDER%` plus `ItemDisplay[]: %NAME%`
- switched to `Live Preview` with `Ber Rune (r30)` selected and clicked `Test`
- expected result: the selected item matches line 1
- repeated with `ItemDisplay[r30s]: %RED%Ber Rune%BORDER%`
- expected result: the selected item also matches line 1