### PR TITLE
fix: consume author deep link once

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -5053,6 +5053,8 @@
     var authorParam = urlParams2.get('author');
     if (authorParam && initAuthorImport.openToAuthor) {
       initAuthorImport.openToAuthor(authorParam);
+      urlParams2.delete('author');
+      history.replaceState(null, '', window.location.pathname + (urlParams2.toString() ? '?' + urlParams2.toString() : '') + window.location.hash);
     }
 
     // Code editor events


### PR DESCRIPTION
## What changed
- consumed the `?author=` deep link after the editor auto-opened the matching author import modal
- removed the author query param from the URL so refresh does not reopen the modal forever

## Why
- `Load in Editor` links from the Community Filters page left `?author=` in the address bar
- after closing the modal, refreshing the page reopened it every time instead of returning to normal editor behavior

## How tested
- before fix: opened `editor.html?author=Wolfie`, closed the modal, refreshed, and the modal opened again
- after fix: repeated the same repro and the modal stayed closed after refresh
- verified the first load still auto-opens the correct author import modal