### PR TITLE
fix: clear FAQ highlights on reset

### DIFF
--- a/js/faq.js
+++ b/js/faq.js
@@ -141,6 +141,7 @@
       });
       resultCount.textContent = '';
       noResults.classList.add('hidden');
+      if (faqData) highlightMatches([]);
       history.replaceState(null, '', window.location.pathname);
       return;
     }


### PR DESCRIPTION
## What changed
- clear FAQ question highlights when the search box is reset
- keep the existing FAQ reset behavior for group expansion, result count, and URL cleanup

## Why
- searching the FAQ highlights matching words in question titles, but clearing the search only reset the list state
- the old highlight markup stayed visible, so the page looked partially filtered even after search was cleared

## How tested
- opened the FAQ search logic with a DOM repro harness
- searched for `filter`
- expected result: matching question text is highlighted
- cleared the search query
- expected result: the same question text returns to plain text with no highlight markup
