### PR TITLE
fix: preserve filters search on load

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -39,6 +39,8 @@
         '</div>';
       grid.appendChild(card);
     });
+
+    filterCards(searchInput ? searchInput.value : '');
   }
 
   function escapeHtml(str) {


### PR DESCRIPTION
## What changed
- reapply the current filters-page search query after the filter cards finish rendering
- keeps the existing live search logic, but now it also works when the user types before loading completes

## Why
- the Filters page accepts typing immediately, but the first render replaced the filtered view with the full card list
- users had to type again to get the search they already entered to take effect

## How tested
- opened the Filters page logic with a DOM repro harness
- set the search box to `wolf` before rendering cards
- rendered two cards: one matching and one non-matching
- expected result before fix: all cards stayed visible
- expected result after fix: only the matching card stays visible immediately
