### PR TITLE
fix: consume wizard deep link once

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -2402,6 +2402,9 @@
     var urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get('wizard') === 'true') {
       openWizard();
+      urlParams.delete('wizard');
+      var nextSearch = urlParams.toString();
+      history.replaceState(null, '', window.location.pathname + (nextSearch ? '?' + nextSearch : '') + window.location.hash);
     }
 
     // Wire up option buttons


### PR DESCRIPTION
## What changed
- treat `?wizard=true` as a one-time deep link in the editor
- remove only the `wizard` query param after auto-opening the modal, while preserving any other params and the hash

## Why
- the editor homepage CTA opens the wizard through `editor.html?wizard=true`
- because the query flag stayed in the URL, refreshing the page reopened the wizard every time

## How tested
- loaded the editor auto-open logic with `?wizard=true`
- expected result: first load opens the wizard once
- simulated a refresh using the resulting URL
- expected result after fix: refresh stays on the normal editor without reopening the modal
