### PR TITLE
fix: hide preview continue chains correctly

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1814,7 +1814,7 @@
         return {
           matched: true,
           rule: rule,
-          hidden: finalOutput === '' && !anyMatched,
+          hidden: finalOutput === '',
           output: finalOutput,
           continued: anyMatched,
           allRules: allMatchedRules


### PR DESCRIPTION
## What changed
- fix live preview so a terminal empty-output rule still hides the item after earlier `%CONTINUE%` matches
- keep `%CONTINUE%` chains that end in a normal output rendering as before

## Why
- the preview tracked chained matches, but it only marked an item hidden when the empty terminal rule was also the first match
- that made `%CONTINUE%` + hide chains look visible in preview even though the terminal rule was empty

## How tested
- loaded the preview matcher with `ItemDisplay[key]: %NAME%%CONTINUE%` followed by `ItemDisplay[key]:`
- tested against a `key` preview item
- expected result before fix: item was incorrectly reported as visible
- expected result after fix: item is reported hidden
- control check: replacing the second rule with `ItemDisplay[]: %NAME%` still reports the item visible
