### PR TITLE
fix: preview description-only rules accurately

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -2253,7 +2253,7 @@
       }
     }
 
-    return result || escapeHtml(item.name);
+    return result;
   }
 
   function escapeHtml(str) {


### PR DESCRIPTION
## What changed
- stop falling back to the base item name when a preview rule renders no visible name text
- this makes description-only outputs like `{Only desc}` preview as name-hidden instead of showing the item name

## Why
- the live preview stripped description braces for inline rendering, then replaced the empty result with the base item name
- that made description-only rules look like they still showed the item name even though the rendered name portion was empty

## How tested
- loaded the preview functions with `ItemDisplay[key]: {Only desc}` and tested a `key` item
- expected result before fix: preview incorrectly rendered `Key`
- expected result after fix: preview renders no visible item name
- control check: `ItemDisplay[key]: %NAME%` still renders `Key`
