### PR TITLE
fix: parse numeric condition codes

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1977,7 +1977,7 @@
     }
 
     // Value condition: CODE<val, CODE>val, CODE=val, CODE~min-max
-    var valueMatch = token.match(/^([A-Z]+)([<>=~])(.+)$/);
+    var valueMatch = token.match(/^([A-Z0-9]+)([<>=~])(.+)$/);
     if (valueMatch) {
       var code = valueMatch[1];
       var op = valueMatch[2];


### PR DESCRIPTION
## What changed
- let the preview parser read numeric condition codes like `STAT360`, `SK263`, `CLSK1`, and `TABSK3`

## Why
- those codes are used by real template rules, but the preview matcher treated them as non-matching text
- that made skill/stat-based rules look broken in Live Preview

## How tested
- ran the preview matcher on rules using `STAT360=27`, `SK263>2`, `CLSK1>1`, and `TABSK3>0`
- expected result before fix: all four failed to match
- expected result after fix: all four match
- control check: a normal item-code rule like `amu` still matches
