### PR TITLE
fix: make splash page responsive

### DIFF
--- a/splash.html
+++ b/splash.html
@@ -255,6 +255,36 @@
     border-radius: 50%;
     flex-shrink: 0;
   }
+
+  @media (max-width: 860px) {
+    body {
+      padding: 12px;
+      align-items: flex-start;
+      justify-content: flex-start;
+    }
+
+    .splash {
+      width: 100%;
+      height: auto;
+      flex-direction: column;
+    }
+
+    .left {
+      width: 100%;
+      padding: 28px 24px 12px;
+    }
+
+    .right {
+      width: 100%;
+      height: auto;
+      padding: 0 16px 16px;
+    }
+
+    .editor-preview {
+      height: auto;
+      min-height: 320px;
+    }
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## What changed
- make the new `splash.html` layout responsive on narrow screens
- stack the splash card vertically and let the preview pane size naturally on mobile

## Why
- the splash page used a fixed 800px-wide layout, which overflowed on phones and small windows
- that made the page harder to use on mobile and caused horizontal scrolling

## How tested
- reviewed the layout at a ~375px viewport width
- expected result before fix: the 800px splash wrapper overflowed horizontally
- expected result after fix: the layout stacks vertically and fits the viewport
