### PR TITLE
fix: move %CONTINUE% to end of output in name reveals

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -3517,7 +3517,7 @@
         ];
         uniNames.forEach(function (entry) {
           var color = entry[0].indexOf('SET') === 0 ? '%GREEN%' : '%GOLD%';
-          lines.push('ItemDisplay[' + entry[0] + ']: %CONTINUE%' + color + entry[1]);
+          lines.push('ItemDisplay[' + entry[0] + ']: ' + color + entry[1] + '%CONTINUE%');
         });
         lines.push('');
       }


### PR DESCRIPTION
## Summary
- `%CONTINUE%` was placed at the start of the output string in unique/set name reveal rules (line 3520 of `js/editor.js`)
- PD2 filter syntax requires `%CONTINUE%` at the **end** of the output string
- Moved `%CONTINUE%` from the beginning to the end of the output

## Test plan
- [ ] Generate a filter with unique/set name reveals enabled
- [ ] Verify the output lines follow the format `ItemDisplay[...]: %GOLD%Name%CONTINUE%` (not `ItemDisplay[...]: %CONTINUE%%GOLD%Name`)
- [ ] Load the generated filter in PD2 and confirm unique/set items display their names correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)