### PR TITLE
fix: connect %CONTINUE% chip to rule generation

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -713,7 +713,7 @@
                   </div>
 
                   <label class="builder-label">Continue</label>
-                  <div class="chip-group" data-field="continue">
+                  <div class="chip-group" data-field="continueKw">
                     <button class="chip active" data-value="">No</button>
                     <button class="chip" data-value="%CONTINUE%">%CONTINUE%</button>
                   </div>

--- a/js/editor.js
+++ b/js/editor.js
@@ -2299,7 +2299,7 @@
       var showChip = document.querySelector('[data-field="action"] [data-value="show"]');
       var nameChip = document.querySelector('[data-field="nameDisplay"] [data-value="%NAME%"]');
       var noneNotify = document.querySelector('[data-field="notify"] [data-value=""]');
-      var noContinue = document.querySelector('[data-field="continue"] [data-value=""]');
+      var noContinue = document.querySelector('[data-field="continueKw"] [data-value=""]');
       var noMap = document.querySelector('[data-field="mapIcon"] [data-value=""]');
       if (showChip) showChip.classList.add('active');
       if (nameChip) nameChip.classList.add('active');


### PR DESCRIPTION
## Summary

- `editor.html` had the Continue chip group using `data-field="continue"`
- `updateGeneratedRule()` in `editor.js` reads `builderState.continueKw`, so clicking the chip wrote to `builderState['continue']` — a property that was never read
- The clear/reset handler in `editor.js` (line ~2302) also queried `[data-field="continue"]` to find the chip to reset

**Fix:** Renamed both HTML `data-field` attributes from `"continue"` to `"continueKw"` to match the property name already used throughout `editor.js`.

Changed files:
- `editor.html` line 716: `data-field="continue"` → `data-field="continueKw"`
- `js/editor.js` line 2302: `[data-field="continue"]` → `[data-field="continueKw"]`

## Test plan

- [ ] Open the Rule Builder, select `%CONTINUE%` chip — verify the generated rule now includes `%CONTINUE%`
- [ ] Select the `No` chip — verify `%CONTINUE%` is removed from the generated rule
- [ ] Clear the rule form — verify the Continue chip resets to `No` (active state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)