### PR TITLE
fix: use PD2 class abbreviations in generated filter rules

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -3944,7 +3944,7 @@
       lines.push('// ============================================================');
       lines.push('// UNID MAGIC & RARE CLASS ITEM DISPLAY');
       lines.push('// ============================================================');
-      var classUpperMap = {ZON:'AMAZON',SOR:'SORCERESS',NEC:'NECROMANCER',DIN:'PALADIN',BAR:'BARBARIAN',DRU:'DRUID',SIN:'ASSASSIN'};
+      var classUpperMap = {ZON:'ZON',SOR:'SOR',NEC:'NEC',DIN:'DIN',BAR:'BAR',DRU:'DRU',SIN:'SIN'};
       var clNumMap = {ZON:'CL7',SOR:'CL6',NEC:'CL4',DIN:'CL3',BAR:'CL2',DRU:'CL1',SIN:'CL5'};
       if (selectedClasses.length > 0) {
         lines.push('// Your class magic items get extra callout');


### PR DESCRIPTION
## Summary
- `classUpperMap` in `js/editor.js` was mapping class short codes to full names (e.g. `ZON` → `AMAZON`), which were then used in generated `ItemDisplay` filter rules
- PD2 only recognizes the short codes (`ZON`, `SOR`, `NEC`, `DIN`, `BAR`, `DRU`, `SIN`), so all class item callout rules were dead code in-game
- Fixed by mapping each key to itself so generated rules use the correct abbreviations

## Test plan
- [ ] Build a filter with one or more classes selected
- [ ] Verify the generated filter contains conditions like `ItemDisplay[ZON CL7 FILTLVL<2 MAG !ID]` (not `AMAZON`)
- [ ] Confirm class-specific magic/rare item callouts appear in-game

🤖 Generated with [Claude Code](https://claude.com/claude-code)