### PR TITLE
fix: handle blocked code copies

### DIFF
--- a/js/shared.js
+++ b/js/shared.js
@@ -58,6 +58,12 @@
           btn.textContent = 'Copy';
           btn.classList.remove('copied');
         }, 1500);
+      }).catch(function () {
+        btn.textContent = 'Copy failed';
+        setTimeout(function () {
+          btn.textContent = 'Copy';
+          btn.classList.remove('copied');
+        }, 1500);
       });
     });
     pre.appendChild(btn);


### PR DESCRIPTION
## What changed
- added error handling to shared code-block copy buttons in `js/shared.js`
- shows a handled `Copy failed` state instead of leaving a rejected clipboard promise unhandled

## Why
- blocking clipboard access on pages like `guide.html` caused an unhandled `NotAllowedError` when users clicked `Copy`

## How tested
- opened `guide.html` in headless Chrome with `navigator.clipboard.writeText()` forced to reject
- clicked the first `Copy` button
- before: `{"unhandled":"NotAllowedError","button":"Copy"}`
- after: `{"unhandled":null,"button":"Copy failed"}`
