### PR TITLE
fix: simplify map icon color substitution logic

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -824,10 +824,8 @@
 
       if (mapIcon) {
         if (mapIconColor) {
-          output += mapIcon.replace('%', '%').replace(/%$/, '-' + mapIconColor + '%');
-          // Fix: replace e.g. %MAP% with %MAP-0A%
           var iconBase = mapIcon.replace(/%/g, '');
-          output = output.replace(mapIcon, '%' + iconBase + '-' + mapIconColor + '%');
+          output += '%' + iconBase + '-' + mapIconColor + '%';
         } else {
           output += mapIcon;
         }


### PR DESCRIPTION
## Summary

- Removed a no-op `.replace('%', '%')` call that had no effect
- Replaced the fragile two-pass approach (append then search-and-replace on full output string) with a single clean token construction
- The old code risked replacing wrong occurrences of `mapIcon` elsewhere in the output string

## Test plan

- [ ] Verify that map icons with a color specified (e.g. `%MAP%` with color `0A`) produce the correct token `%MAP-0A%` in filter output
- [ ] Verify that map icons without a color still append the icon token unchanged
- [ ] Confirm no regressions in filter generation for items with map icon settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)