### PR TITLE
fix: map SOCK to SOCKETS in Live Preview evaluator

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1982,6 +1982,7 @@
       var code = valueMatch[1];
       var op = valueMatch[2];
       var valStr = valueMatch[3];
+      if (code === 'SOCK') code = 'SOCKETS';
       var itemVal = (item.values && item.values[code] !== undefined) ? item.values[code] : 0;
 
       // GOLD conditions only match gold piles (items with code 'gold')


### PR DESCRIPTION
## Summary

- Preview items store socket count under `SOCKETS`, but wizard-generated rules use `SOCK` as the condition code
- Any `SOCK>0`, `SOCK=4`, etc. conditions always evaluated false in the Live Preview
- Added a one-line alias (`if (code === 'SOCK') code = 'SOCKETS';`) in the value condition evaluator before the item value lookup

## Test plan

- [ ] Create a filter rule with a socket condition (e.g. `SOCK>0` or `SOCK=4`)
- [ ] Open the Live Preview and verify items with sockets are correctly matched/highlighted
- [ ] Verify items without sockets are not matched by `SOCK>0` conditions
- [ ] Confirm no regression in other value-based conditions (GOLD, RUNE, GEM, MAPTIER, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)