### PR TITLE
fix: show both [Eth] and socket count on ETH+socketed items

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -2698,13 +2698,13 @@
       if (wantEthTag || wantSockets) {
         if (wantEthTag && wantSockets) {
           lines.push('// Magic+ items: Eth tag and socket count');
+          lines.push('ItemDisplay[(MAG OR UNI OR SET OR RARE OR CRAFT) !RW ETH SOCK>0]: %NAME% %GRAY%[Eth] [%SOCKETS%]%CONTINUE%');
           lines.push('ItemDisplay[(MAG OR UNI OR SET OR RARE OR CRAFT) ETH]: %NAME% %GRAY%[Eth]%CONTINUE%');
           lines.push('ItemDisplay[(MAG OR UNI OR SET OR RARE OR CRAFT) !RW !ETH SOCK>0]: %NAME% [%SOCKETS%]%CONTINUE%');
-          lines.push('ItemDisplay[(MAG OR UNI OR SET OR RARE OR CRAFT) !RW ETH SOCK>0]: %NAME%[%SOCKETS%]%CONTINUE%');
           lines.push('// Normal items: Eth tag and socket count');
+          lines.push('ItemDisplay[NMAG !RW ETH SOCK>0]: %GRAY%%NAME% [Eth] [%SOCKETS%]%CONTINUE%');
           lines.push('ItemDisplay[NMAG ETH]: %GRAY%%NAME% [Eth]%CONTINUE%');
           lines.push('ItemDisplay[NMAG !RW !ETH SOCK>0]: %GRAY%%NAME% [%SOCKETS%]%CONTINUE%');
-          lines.push('ItemDisplay[NMAG !RW ETH SOCK>0]: %GRAY%%NAME%[%SOCKETS%]%CONTINUE%');
         } else if (wantEthTag) {
           lines.push('ItemDisplay[(MAG OR UNI OR SET OR RARE OR CRAFT) ETH]: %NAME% %GRAY%[Eth]%CONTINUE%');
           lines.push('ItemDisplay[NMAG ETH]: %GRAY%%NAME% [Eth]%CONTINUE%');


### PR DESCRIPTION
## Summary

- ETH+socketed items were only showing `[Eth]` because the ETH-only `CONTINUE` rule fired first (first-match-wins in PD2)
- Moved combined ETH+SOCK rules before the ETH-only rules in both Magic+ and Normal item blocks
- Updated combined rule output to include both tags: `[Eth] [%SOCKETS%]`

## Test plan

- [ ] Generate a filter with both Eth tag and socket count enabled
- [ ] Verify an ETH+socketed Magic/Rare/Unique/Set/Craft item shows both `[Eth]` and socket count (e.g. `Item Name [Eth] [4]`)
- [ ] Verify an ETH-only (no sockets) item still shows only `[Eth]`
- [ ] Verify a socketed non-ETH item still shows only socket count
- [ ] Repeat above for Normal (white/grey) items

🤖 Generated with [Claude Code](https://claude.com/claude-code)