### PR TITLE
fix: re-show Add Skill button when a skill row is removed

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -608,6 +608,7 @@
         firstRow.querySelector('.skill-op').value = '=';
         firstRow.querySelector('.skill-level').value = '1';
       }
+      addBtn.style.display = '';
       updateGeneratedRule();
     });
 
@@ -618,6 +619,7 @@
       populateSkills(row);
       row.querySelector('.btn-remove-skill').addEventListener('click', function () {
         row.remove();
+        addBtn.style.display = '';
         updateGeneratedRule();
       });
       if (container.querySelectorAll('.skill-row').length >= MAX_SKILLS) {


### PR DESCRIPTION
## Summary

- The Add Skill button was hidden when `MAX_SKILLS` rows were present but never re-shown when a row was removed
- Added `addBtn.style.display = '';` in both the first-row remove handler and the dynamically-added row remove handler
- Users could be permanently locked out of adding skills until clearing the entire builder

## Test plan

- [ ] Open the skill builder and add skill rows until the Add Skill button hides (MAX_SKILLS reached)
- [ ] Remove a skill row — confirm the Add Skill button reappears
- [ ] Verify this works when removing the first/static row as well as dynamically-added rows
- [ ] Confirm the button hides again if rows are added back to MAX_SKILLS

🤖 Generated with [Claude Code](https://claude.com/claude-code)