### PR TITLE
fix: move rune stacking rule after tier decoration rules

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -2889,16 +2889,17 @@
       lines.push('// --- Mid Runes (Lem - Mal) ---');
       lines.push('ItemDisplay[RUNE>19 RUNE<24]: ' + colorMidRune + decoLow_L + '%RUNENAME% Rune' + decoLow_R + ' (#%RUNENUM%)' + midRuneNotify);
 
-      // Rune stacking display (from Wolfie/HiimFilter)
-      lines.push('// --- Rune Stack Display ---');
-      lines.push('ItemDisplay[RUNE>0 QTY>1]: %NAME% %TAN%x%QTY%{%NAME%}%CONTINUE%');
-      lines.push('');
-
       // Tier 4: Low Runes (El #1 through Fal #19)
       lines.push('// --- Low Runes (El - Fal) ---');
       lines.push('ItemDisplay[RUNE>14 RUNE<20]: ' + colorLowRune + '%RUNENAME% Rune (#%RUNENUM%)' + lowRuneDot);
       lines.push('ItemDisplay[RUNE>10 RUNE<15]: %ORANGE%%RUNENAME% (#%RUNENUM%)');
       lines.push('ItemDisplay[RUNE>0 RUNE<11]: %ORANGE%%RUNENAME% (#%RUNENUM%)');
+      lines.push('');
+
+      // Rune stacking display (from Wolfie/HiimFilter)
+      // Must come after all tier rules so CONTINUE doesn't suppress tier decoration
+      lines.push('// --- Rune Stack Display ---');
+      lines.push('ItemDisplay[RUNE>0 QTY>1]: %NAME% %TAN%x%QTY%{%NAME%}%CONTINUE%');
       lines.push('');
 
       // ==========================


### PR DESCRIPTION
## Summary

- The rune stacking `CONTINUE` rule (`ItemDisplay[RUNE>0 QTY>1]`) was placed **before** the Low Runes tier block in the generated filter output
- Since PD2 uses first-match-wins, stacked mid/high runes would match the stacking rule first via `CONTINUE`, then skip the tier decoration rules that should apply color and icons
- Moved the Rune Stack Display block to **after** all four rune tier sections (High, Mid-High, Mid, Low) so tier decoration always applies first

## Test plan

- [ ] Generate a filter with rune settings enabled
- [ ] Verify the generated filter has `// --- Rune Stack Display ---` appearing after `// --- Low Runes (El - Fal) ---`
- [ ] In-game: confirm stacked mid/high runes (e.g. 2x Ist) still show their color and icon decoration

🤖 Generated with [Claude Code](https://claude.com/claude-code)