### PR TITLE
fix: replace invalid %FRW% output token with %STAT96%

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -4238,7 +4238,7 @@
       lines.push('ItemDisplay[(ARMOR OR WEAPON OR rin OR amu) (MAG OR RARE OR CRAFT) ID FCR>0]: %TAN%%STAT105%FCR %NAME%%CONTINUE%{%NAME%}');
       lines.push('ItemDisplay[(ARMOR OR WEAPON OR rin OR amu) (MAG OR RARE OR CRAFT) ID IAS>0 !WAND !SOR]: %ORANGE%%STAT93%IAS %NAME%%CONTINUE%{%NAME%}');
       lines.push('ItemDisplay[(ARMOR OR WEAPON OR rin OR amu) (MAG OR RARE OR CRAFT) ID FHR>0]: %GOLD%%STAT99%FHR %NAME%%CONTINUE%{%NAME%}');
-      lines.push('ItemDisplay[(ARMOR OR WEAPON OR rin OR amu) (MAG OR RARE OR CRAFT) ID FRW>0]: %GOLD%%FRW%FRW %NAME%%CONTINUE%{%NAME%}');
+      lines.push('ItemDisplay[(ARMOR OR WEAPON OR rin OR amu) (MAG OR RARE OR CRAFT) ID FRW>0]: %GOLD%%STAT96%FRW %NAME%%CONTINUE%{%NAME%}');
       lines.push('ItemDisplay[(ARMOR OR WEAPON OR rin OR amu) (MAG OR RARE OR CRAFT) ID FBR>0]: %ORANGE%%STAT102%FBR %NAME%%CONTINUE%{%NAME%}');
       // Resistances
       lines.push('// --- Resistances ---');


### PR DESCRIPTION
## Summary
- `%FRW%` is not a valid PD2 output token and was used incorrectly in the generated filter output for Faster Run/Walk
- FRW is stat ID 96 in Diablo II, so the correct token is `%STAT96%`
- This matches the established pattern used for similar stats (e.g. FBR uses `%STAT102%`, FHR uses `%STAT99%`, IAS uses `%STAT93%`)
- The label text "FRW" is preserved; only the output token is corrected

## Test plan
- [ ] Generate a filter with FRW enabled and verify the output line reads `%STAT96%FRW` instead of `%FRW%FRW`
- [ ] Confirm the generated filter loads in PD2 without errors related to the FRW line
- [ ] Check that FRW stat values display correctly in-game on eligible items

🤖 Generated with [Claude Code](https://claude.com/claude-code)