### PR TITLE
fix: initialize builderState.tier as array

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -21,7 +21,7 @@
   // ==========================================
   var builderState = {
     quality: '',
-    tier: '',
+    tier: [],
     properties: [],
     itemcat: [],
     equipment: '',


### PR DESCRIPTION
## Summary
- `builderState.tier` was initialized as `''` (empty string) on line 24 of `js/editor.js`
- The tier chip group uses `data-multi="true"`, which expects an array value
- Changed initialization from `''` to `[]` for type consistency

## Test plan
- [ ] Open the Build My Filter wizard
- [ ] Verify tier chip group functions correctly as a multi-select
- [ ] Confirm no regressions in filter building with tier selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)