### PR TITLE
fix: hide grail pane in goToLine tab switch

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1569,6 +1569,7 @@
     document.querySelector('[data-tab="code"]').classList.add('active');
     document.getElementById('pane-code').style.display = 'block';
     document.getElementById('pane-preview').style.display = 'none';
+    document.getElementById('pane-grail').style.display = 'none';
 
     var text = codeEditor.value;
     var lines = text.split('\n');


### PR DESCRIPTION
## Summary
- `goToLine()` was hiding `pane-preview` but not `pane-grail` when switching to the code tab
- This could cause both panes to display simultaneously
- Added the missing `document.getElementById('pane-grail').style.display = 'none';` line after the `pane-preview` hide

## Test plan
- [ ] Open a filter file in the editor
- [ ] Navigate to the Grail tab so `pane-grail` is visible
- [ ] Trigger `goToLine()` (e.g. via a rule error link)
- [ ] Verify the editor switches to the code tab and `pane-grail` is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)