### PR TITLE
fix: prevent inserting placeholder text into filter

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1089,6 +1089,7 @@
   // Insert rule into editor
   // ==========================================
   function insertRule() {
+    if (generatedCode.classList.contains('empty-state')) return;
     var rule = generatedCode.textContent;
     var val = codeEditor.value;
     var pos = codeEditor.selectionStart;
@@ -1122,6 +1123,7 @@
   }
 
   function insertRuleAtTop() {
+    if (generatedCode.classList.contains('empty-state')) return;
     var rule = generatedCode.textContent;
     var val = codeEditor.value;
     var suffix = val.length > 0 && !val.startsWith('\n') ? '\n' : '';
@@ -1133,6 +1135,7 @@
   }
 
   function insertRuleAtEnd() {
+    if (generatedCode.classList.contains('empty-state')) return;
     var rule = generatedCode.textContent;
     var val = codeEditor.value;
     var prefix = val.length > 0 && !val.endsWith('\n') ? '\n' : '';


### PR DESCRIPTION
## Summary
- `insertRule`, `insertRuleAtTop`, and `insertRuleAtEnd` all read `generatedCode.textContent` without checking if the builder was in its empty/placeholder state
- This caused the literal text "Use the Rule Builder to generate a rule" to be inserted into the filter when no rule had been built
- Added an `empty-state` CSS class guard (`if (generatedCode.classList.contains('empty-state')) return;`) at the top of all three functions to bail out early

## Test plan
- [ ] Open the editor with an empty Rule Builder (no rule generated yet)
- [ ] Click Insert, Insert at Top, and Insert at End — nothing should be inserted into the filter
- [ ] Build a rule in the Rule Builder, then click each insert button — the rule should be inserted correctly as before

Generated with [Claude Code](https://claude.com/claude-code)