### PR TITLE
fix: preserve URL hash when clearing FAQ search

### DIFF
--- a/js/faq.js
+++ b/js/faq.js
@@ -142,7 +142,7 @@
       resultCount.textContent = '';
       noResults.classList.add('hidden');
       if (faqData) highlightMatches([]);
-      history.replaceState(null, '', window.location.pathname);
+      history.replaceState(null, '', window.location.pathname + window.location.hash);
       return;
     }
 


### PR DESCRIPTION
## Summary
- `history.replaceState` on search clear was calling `window.location.pathname` only, stripping the URL hash
- Users who followed a direct anchor link (e.g. `faq.html#some-item`) would lose that anchor after searching and clearing
- Fix appends `window.location.hash` so the anchor is preserved

## Test plan
- [ ] Open `faq.html#some-item` directly via an anchor link
- [ ] Type something in the search box
- [ ] Clear the search box
- [ ] Verify the URL still contains `#some-item`

🤖 Generated with [Claude Code](https://claude.com/claude-code)