### PR TITLE
fix: guard editor.js init against missing DOM elements

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -5039,6 +5039,7 @@
   // Initialize everything
   // ==========================================
   function init() {
+    if (!codeEditor) return; // Not on editor page
     loadFromStorage();
     updateLineNumbers();
 


### PR DESCRIPTION
## Summary
- `editor.js` is loaded dynamically from `test-color.html`, but its IIFE immediately calls `init()`, which accesses DOM elements that don't exist on that page
- Added an early return guard at the top of `init()`: `if (!codeEditor) return;`
- `codeEditor` is `document.getElementById('code-editor')` (line 11) — null when not on the editor page, making it a reliable sentinel

## Test plan
- [ ] Open `test-color.html` — no TypeError crashes in the console
- [ ] Open the main editor page — editor initialises normally as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)