### PR TITLE
fix: prevent double-click on wizard Build Filter button

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -2395,6 +2395,7 @@
 
     function openWizard() {
       modal.style.display = 'flex';
+      btnNext.disabled = false;
       goToStep(1);
     }
 
@@ -2446,6 +2447,7 @@
       if (currentStep < totalSteps) {
         goToStep(currentStep + 1);
       } else {
+        btnNext.disabled = true;
         buildFilter();
       }
     });


### PR DESCRIPTION
## Summary

- Disables the `btnNext` button immediately before calling `buildFilter()` to prevent a double-click from firing the function twice
- Re-enables `btnNext` inside `openWizard()` so the button works correctly the next time the wizard is opened

## Test plan

- [ ] Open the Build My Filter wizard
- [ ] Step through to the final step
- [ ] Rapidly double-click the "Build Filter" button — confirm the filter is only generated once
- [ ] Close the wizard and reopen it — confirm the "Next" / "Build Filter" button is enabled and functional again

Generated with [Claude Code](https://claude.com/claude-code)