### PR TITLE
fix: replace PoE currency names with neutral sound labels

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -688,16 +688,16 @@
                   <p class="text-muted builder-hint">To hear sounds in-game: type <code>/sound XXXX</code> in chat (e.g. <code>/sound 4716</code>)</p>
                   <select class="builder-select" id="sound-select">
                     <option value="">None</option>
-                    <option value="4714">4714 — Exalted Orb</option>
-                    <option value="4715">4715 — Divine Orb</option>
-                    <option value="4716">4716 — Mirror of Kalandra</option>
+                    <option value="4714">4714 — Alert 1 (bright)</option>
+                    <option value="4715">4715 — Alert 2 (medium)</option>
+                    <option value="4716">4716 — Alert 3 (high)</option>
                     <option value="4717">4717 — General</option>
-                    <option value="4718">4718 — Regal Orb</option>
-                    <option value="4719">4719 — Chaos Orb</option>
-                    <option value="4720">4720 — Fusing</option>
-                    <option value="4721">4721 — Alchemy Orb</option>
-                    <option value="4722">4722 — Vaal Orb</option>
-                    <option value="4723">4723 — Blessed Orb</option>
+                    <option value="4718">4718 — Alert 4 (mid)</option>
+                    <option value="4719">4719 — Alert 5 (sharp)</option>
+                    <option value="4720">4720 — Alert 6 (soft)</option>
+                    <option value="4721">4721 — Alert 7 (low)</option>
+                    <option value="4722">4722 — Alert 8 (deep)</option>
+                    <option value="4723">4723 — Alert 9 (light)</option>
                     <option value="4724">4724</option>
                     <option value="4725">4725</option>
                     <option value="4726">4726</option>


### PR DESCRIPTION
## Summary
- Sound dropdown options (4714-4723) previously used Path of Exile item names (Exalted Orb, Divine Orb, Mirror of Kalandra, etc.) which are meaningless in a D2/PD2 context
- Replaced with neutral descriptive labels (Alert 1 (bright), Alert 2 (medium), etc.)
- ID 4717 "General" was already neutral and is unchanged

## Test plan
- [ ] Open editor.html and navigate to the Sound dropdown
- [ ] Verify the dropdown shows neutral descriptive names instead of PoE currency names
- [ ] Verify sound IDs (4714-4723) are unchanged