### PR TITLE
fix: handle blocked item-code copies

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -4698,6 +4698,11 @@
             copyEl.textContent = 'copied!';
             copyEl.style.opacity = '1';
             setTimeout(function () { copyEl.textContent = 'copy'; copyEl.style.opacity = ''; }, 1000);
+          }).catch(function () {
+            var copyEl = row.querySelector('.itemcode-copy');
+            copyEl.textContent = 'copy failed';
+            copyEl.style.opacity = '1';
+            setTimeout(function () { copyEl.textContent = 'copy'; copyEl.style.opacity = ''; }, 1000);
           });
         });
         listEl.appendChild(row);
@@ -4742,6 +4747,11 @@
             navigator.clipboard.writeText(item[0]).then(function () {
               var copyEl = row.querySelector('.itemcode-copy');
               copyEl.textContent = 'copied!';
+              copyEl.style.opacity = '1';
+              setTimeout(function () { copyEl.textContent = 'copy'; copyEl.style.opacity = ''; }, 1000);
+            }).catch(function () {
+              var copyEl = row.querySelector('.itemcode-copy');
+              copyEl.textContent = 'copy failed';
               copyEl.style.opacity = '1';
               setTimeout(function () { copyEl.textContent = 'copy'; copyEl.style.opacity = ''; }, 1000);
             });


### PR DESCRIPTION
## What changed
- added error handling to the editor item-code finder copy actions in `js/editor.js`
- covers both the default category list and filtered search results

## Why
- blocking clipboard access on `editor.html` caused an unhandled `NotAllowedError` when an item-code row was clicked

## How tested
- opened `editor.html` in headless Chrome with `navigator.clipboard.writeText()` forced to reject
- clicked one item-code row from the default list, then one from filtered search results
- before: `{"unhandled":"NotAllowedError","copy":"copy"}`
- after: default `{"unhandled":null,"copy":"copy failed"}`, search `{"unhandled":null,"copy":"copy failed"}`
