### PR TITLE
fix: handle blocked FAQ copies

### DIFF
--- a/js/faq.js
+++ b/js/faq.js
@@ -117,6 +117,12 @@
             btn.textContent = 'Copy';
             btn.classList.remove('copied');
           }, 1500);
+        }).catch(function () {
+          btn.textContent = 'Copy failed';
+          setTimeout(function () {
+            btn.textContent = 'Copy';
+            btn.classList.remove('copied');
+          }, 1500);
         });
       });
       pre.appendChild(btn);


### PR DESCRIPTION
## What changed
- added error handling to FAQ answer copy buttons in `js/faq.js`
- shows a handled `Copy failed` state instead of leaving a rejected clipboard promise unhandled

## Why
- blocking clipboard access on `faq.html` caused an unhandled `NotAllowedError` when users clicked a code-block copy button

## How tested
- opened `faq.html` in headless Chrome with `navigator.clipboard.writeText()` forced to reject
- clicked the first FAQ code-block `Copy` button
- before: `{"unhandled":"NotAllowedError","button":"Copy"}`
- after: `{"unhandled":null,"button":"Copy failed"}`
