### PR TITLE
fix: guard grail storage writes

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1360,7 +1360,9 @@
     Object.keys(GRAIL_DATA).forEach(function (cat) { totalItems += GRAIL_DATA[cat].length; });
 
     function saveGrail() {
-      localStorage.setItem('filterforge-grail', JSON.stringify(found));
+      try {
+        localStorage.setItem('filterforge-grail', JSON.stringify(found));
+      } catch (e) {}
     }
 
     function countFound() {


### PR DESCRIPTION
## What changed
- wrapped Holy Grail progress saves in `js/editor.js` so failed `localStorage` writes do not break the tracker

## Why
- clicking grail items threw `QuotaExceededError` when storage writes failed, which stopped the UI update

## How tested
- opened `editor.html` in headless Chrome with `localStorage.setItem()` forced to throw
- switched to the Grail tab and clicked the first grail item
- before: `{"unhandled":"QuotaExceededError","found":false}`
- after: `{"unhandled":null,"found":true}`
