### PR TITLE
fix: keep grail filtered counts accurate

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1404,7 +1404,7 @@
             el.className = 'grail-item' + (found[key] ? ' found' : '');
             el.querySelector('.grail-check').innerHTML = found[key] ? '&#9745;' : '&#9744;';
             updateProgress();
-            header.textContent = category + ' (' + items.filter(function (it) { return found[category + ':' + it.name]; }).length + '/' + items.length + ')';
+            header.textContent = category + ' (' + filtered.filter(function (it) { return found[category + ':' + it.name]; }).length + '/' + filtered.length + ')';
           });
           itemsDiv.appendChild(el);
         });


### PR DESCRIPTION
## What changed
- kept Holy Grail category header counts tied to the active filtered list in `js/editor.js`

## Why
- after searching the Grail list, clicking an item updated the header back to full-category totals instead of the filtered totals still on screen

## How tested
- opened `editor.html` in headless Chrome
- switched to the Grail tab
- searched for `shako`
- before click: `Helms (0/1)`
- after click before fix: `Helms (1/22)`
- after click now: `Helms (1/1)`
