### PR TITLE
fix: remove duplicate CSS declaration in splash.html

### DIFF
--- a/splash.html
+++ b/splash.html
@@ -77,7 +77,6 @@
     background-clip: text;
     line-height: 1.05;
     padding-bottom: 4px;
-    -webkit-text-fill-color: transparent;
     display: inline-block;
     overflow: visible;
   }


### PR DESCRIPTION
## Summary
- Removes the duplicate `-webkit-text-fill-color: transparent` declaration in the `.title` style block of `splash.html`

## Test plan
- [ ] Open `splash.html` in a browser and verify the title gradient still renders correctly
- [ ] Confirm only one `-webkit-text-fill-color` declaration exists in `.title`

🤖 Generated with [Claude Code](https://claude.com/claude-code)