### PR TITLE
fix: add min-max format hint for between (~) operator

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -539,7 +539,7 @@
                       <option value="=">=</option>
                       <option value="~">~ (between)</option>
                     </select>
-                    <input type="text" class="value-val" placeholder="value" size="6" aria-label="Condition value">
+                    <input type="text" class="value-val" placeholder="value (min-max for ~)" size="6" aria-label="Condition value">
                     <button class="btn-icon btn-remove-value" title="Remove" aria-label="Remove condition">&times;</button>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Updates the value condition input placeholder from `value` to `value (min-max for ~)` so users know the `~` (between) operator requires a `min-max` format.

## Test plan
- [ ] Open editor, add a value condition row, confirm placeholder reads `value (min-max for ~)`
- [ ] Verify other operators still work with the updated placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)