### PR TITLE
fix: replace raw filter tokens with plain English in wizard

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -138,11 +138,11 @@
                 </button>
                 <button class="wizard-opt" data-value="minimal">
                   <strong>Minimal</strong>
-                  <span>Small minimap dots (%DOT%) on valuable items — no sounds</span>
+                  <span>Small minimap dots (minimap dots) on valuable items — no sounds</span>
                 </button>
                 <button class="wizard-opt" data-value="standard">
                   <strong>Standard</strong>
-                  <span>Map icons (%MAP%) on good drops + dots on lesser items — no sounds</span>
+                  <span>Map icons (minimap icons) on good drops + dots on lesser items — no sounds</span>
                 </button>
                 <button class="wizard-opt" data-value="full">
                   <strong>Full</strong>
@@ -150,7 +150,7 @@
                 </button>
                 <button class="wizard-opt" data-value="max">
                   <strong>Maximum</strong>
-                  <span>Large bordered minimap icons (%BORDER%) + sounds on top drops, map icons on mid drops, dots on everything else</span>
+                  <span>Large bordered minimap icons (large minimap borders) + sounds on top drops, map icons on mid drops, dots on everything else</span>
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Replaces `(%DOT%)` with `(minimap dots)` in the Minimal notification option
- Replaces `(%MAP%)` with `(minimap icons)` in the Standard notification option
- Replaces `(%BORDER%)` with `(large minimap borders)` in the Maximum notification option

These raw filter tokens were exposed to beginners in wizard step 3. This change replaces them with plain English descriptions so users understand what they mean.

## Test plan
- [ ] Open the Build My Filter wizard and proceed to step 3
- [ ] Verify notification options show plain English descriptions instead of raw tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)