### PR TITLE
fix: show 'None' instead of '-rw' for skipped runeword bases

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -2490,7 +2490,7 @@
         { l: 'Color Theme', v: label('', choices.colorprofile) || 'Default' },
         { l: 'Decoration', v: label('', choices.decoration) || 'Arrows' },
         { l: 'Extra Info', v: choices.extras.length ? choices.extras.map(function (x) { return label('', x); }).join(', ') : 'None' },
-        { l: 'Runeword Bases', v: label('', choices.rwbases + '-rw') },
+        { l: 'Runeword Bases', v: choices.rwbases ? label('', choices.rwbases + '-rw') : 'None' },
         { l: 'Hide Consumables', v: choices.consumables.length ? choices.consumables.map(function (x) { return label('', x); }).join(', ') : 'None' },
         { l: 'Tooltips', v: choices.tooltips.length ? choices.tooltips.map(function (x) { return label('', x); }).join(', ') : 'None' }
       ];
@@ -2659,7 +2659,7 @@
       lines.push('// Color Theme: ' + (label('', c.colorprofile) || 'Default'));
       lines.push('// Decoration: ' + (label('', c.decoration) || 'Arrows'));
       lines.push('// Extras: ' + (c.extras.length ? c.extras.map(function (x) { return label('', x); }).join(', ') : 'None'));
-      lines.push('// RW Bases: ' + (label('', c.rwbases + '-rw') || 'None'));
+      lines.push('// RW Bases: ' + (c.rwbases ? label('', c.rwbases + '-rw') : 'None'));
       lines.push('// Consumables: ' + (c.consumables.length ? c.consumables.map(function (x) { return label('', x); }).join(', ') : 'Default'));
       lines.push('// Tooltips: ' + (c.tooltips.length ? c.tooltips.map(function (x) { return label('', x); }).join(', ') : 'None'));
       lines.push('// ============================================================');


### PR DESCRIPTION
## Summary
- Fixes the wizard summary panel to show `None` instead of the raw `-rw` suffix when the user skips step 7 (Runeword Bases).
- Also fixes the filter header comment output to use the same guard so `// RW Bases:` shows `None` rather than `-rw`.

## Test plan
- [ ] Open Build My Filter wizard, skip step 7, reach the summary — confirm "Runeword Bases" shows `None`
- [ ] Generate the filter and check the header comment block — confirm `// RW Bases: None`
- [ ] Select a runeword base option and confirm the label still renders correctly (e.g. `3-os-rw`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)