### PR TITLE
fix: add mutual exclusion note to Armor Slot and Weapon Type

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -434,7 +434,7 @@
                   <button class="chip" data-value="WEAPON">Weapon</button>
                 </div>
 
-                <label class="builder-label">Armor Slot</label>
+                <label class="builder-label">Armor Slot<span class="text-muted"> (clears weapon type)</span></label>
                 <div class="chip-group" data-field="equipment">
                   <button class="chip" data-value="HELM">Helm</button>
                   <button class="chip" data-value="CHEST">Chest</button>
@@ -445,7 +445,7 @@
                   <button class="chip" data-value="CIRC">Circlet</button>
                 </div>
 
-                <label class="builder-label">Weapon Type</label>
+                <label class="builder-label">Weapon Type<span class="text-muted"> (clears armor slot)</span></label>
                 <div class="chip-group" data-field="weapons">
                   <button class="chip" data-value="AXE">Axe</button>
                   <button class="chip" data-value="MACE">Mace</button>


### PR DESCRIPTION
## Summary
- Adds `(clears weapon type)` note to the Armor Slot label
- Adds `(clears armor slot)` note to the Weapon Type label
- Helps users understand these two fields are mutually exclusive

## Test plan
- [ ] Open editor.html and inspect the Armor Slot and Weapon Type labels
- [ ] Verify the muted notes appear next to each label
- [ ] Verify selecting an armor slot clears weapon type selection (and vice versa) in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)