### PR TITLE
fix: clarify wizard step 1 instructions

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -102,7 +102,7 @@
             <!-- Step 1: Class -->
             <div class="wizard-step" id="wiz-step-1">
               <h3>What class are you playing?</h3>
-              <p class="text-muted">This adds class-specific items, weapons, and set pieces to your filter at higher strictness levels. <strong>You don't have to pick one</strong> — skip this step if you don't need class-specific enrichment. <strong>Select all that apply.</strong></p>
+              <p class="text-muted">This adds class-specific items, weapons, and set pieces to your filter at higher strictness levels. <strong>You don't have to pick one</strong> — press Next to continue if you don't need class-specific enrichment. <strong>Select all that apply.</strong></p>
               <div class="wizard-options" data-wiz="class" data-multi="true">
                 <button class="wizard-opt" data-value="amazon">Amazon</button>
                 <button class="wizard-opt" data-value="sorceress">Sorceress</button>


### PR DESCRIPTION
## Summary
- Replaces "skip this step" with "press Next to continue" in wizard step 1

The step 1 text told users to "skip this step" but there is no skip button — only a Next button. This change makes the instruction accurate.

## Test plan
- [ ] Open the Build My Filter wizard
- [ ] Verify step 1 text now reads "press Next to continue" instead of "skip this step"

🤖 Generated with [Claude Code](https://claude.com/claude-code)