### PR TITLE
fix: add Open Graph meta tags to all pages

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -14,6 +14,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Filter Editor — Filter Forge</title>
   <meta name="description" content="Create and edit Project Diablo 2 item filters with a visual rule builder, live preview, and code editor.">
+  <meta property="og:title" content="Filter Editor — Filter Forge">
+  <meta property="og:description" content="Build and customize PD2 loot filters with a visual editor.">
   <link rel="stylesheet" href="css/main.css">
   <link rel="stylesheet" href="css/editor.css">
 </head>

--- a/faq.html
+++ b/faq.html
@@ -14,6 +14,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>FAQ — Filter Forge</title>
   <meta name="description" content="Frequently asked questions about Project Diablo 2 item filters.">
+  <meta property="og:title" content="FAQ — Filter Forge">
+  <meta property="og:description" content="Frequently asked questions about Filter Forge and PD2 loot filters.">
   <link rel="stylesheet" href="css/main.css">
   <link rel="stylesheet" href="css/faq.css">
 </head>

--- a/filters.html
+++ b/filters.html
@@ -14,6 +14,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Community Filters — Filter Forge</title>
   <meta name="description" content="Browse community-maintained item filters for Project Diablo 2.">
+  <meta property="og:title" content="Community Filters — Filter Forge">
+  <meta property="og:description" content="Browse and import community PD2 loot filters.">
   <link rel="stylesheet" href="css/main.css">
   <link rel="stylesheet" href="css/filters.css">
 </head>

--- a/guide.html
+++ b/guide.html
@@ -14,6 +14,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Getting Started — Filter Forge</title>
   <meta name="description" content="Step-by-step guide to installing and customizing PD2 item filters.">
+  <meta property="og:title" content="Getting Started — Filter Forge">
+  <meta property="og:description" content="Learn how to create and use PD2 loot filters.">
   <link rel="stylesheet" href="css/main.css">
   <link rel="stylesheet" href="css/guide.css">
 </head>


### PR DESCRIPTION
## Summary
- Adds `og:title` and `og:description` Open Graph meta tags to `editor.html`, `guide.html`, `faq.html`, and `filters.html`
- Tags are inserted after the existing `<meta name="description">` tag in each page's `<head>`

## Test plan
- [ ] Verify OG tags appear correctly in the HTML source of each page
- [ ] Use a social preview tool (e.g. opengraph.xyz) to confirm tags are picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)