### PR TITLE
fix: add tooltips to grail notification options

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -958,9 +958,9 @@
                   <div class="grail-style-row">
                     <label for="grail-notify">Notification</label>
                     <select id="grail-notify" aria-label="Grail notification type">
-                      <option value="%BORDER-05%" selected>Border (large)</option>
-                      <option value="%MAP-05%">Map icon (medium)</option>
-                      <option value="%DOT-05%">Dot (small)</option>
+                      <option value="%BORDER-05%" selected title="Dark blue minimap border">Border (large)</option>
+                      <option value="%MAP-05%" title="Dark blue minimap icon">Map icon (medium)</option>
+                      <option value="%DOT-05%" title="Dark blue minimap dot">Dot (small)</option>
                       <option value="">None</option>
                     </select>
                   </div>


### PR DESCRIPTION
## Summary
- Adds `title` attributes to all three grail notification `<select>` options
- Border option: "Dark blue minimap border"
- Map icon option: "Dark blue minimap icon"
- Dot option: "Dark blue minimap dot"

## Test plan
- [ ] Open editor.html, navigate to the Holy Grail section
- [ ] Hover over each option in the Notification dropdown
- [ ] Verify tooltip text appears for each option

🤖 Generated with [Claude Code](https://claude.com/claude-code)