### PR TITLE
fix: use filtered count in grail header during search

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1404,7 +1404,7 @@
             el.className = 'grail-item' + (found[key] ? ' found' : '');
             el.querySelector('.grail-check').innerHTML = found[key] ? '&#9745;' : '&#9744;';
             updateProgress();
-            header.textContent = category + ' (' + items.filter(function (it) { return found[category + ':' + it.name]; }).length + '/' + items.length + ')';
+            header.textContent = category + ' (' + filtered.filter(function (it) { return found[category + ':' + it.name]; }).length + '/' + filtered.length + ')';
           });
           itemsDiv.appendChild(el);
         });


### PR DESCRIPTION
## Summary
- Fixes the grail category header count so that when a search filter is active and a user checks/unchecks an item, the header shows `checked/filtered` rather than `checked/total`.
- The initial render (line 1390) already used `filtered` correctly; the click handler (line 1407) was incorrectly referencing `items` (the full unfiltered list).

## Test plan
- [ ] Open Holy Grail, type a search term that narrows the list
- [ ] Check an item — confirm the header count reflects the filtered subset (e.g. `1/3` not `1/47`)
- [ ] Clear the search and confirm header counts revert to full totals on re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)