### PR TITLE
fix: correct Crafting Info wizard description

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -260,7 +260,7 @@
                 </button>
                 <button class="wizard-opt" data-value="crafting">
                   <strong>Crafting Info</strong>
-                  <span>Show ALVL and crafted ALVL on magic items</span>
+                  <span>Show crafted ALVL on magic items</span>
                 </button>
                 <button class="wizard-opt" data-value="eth">
                   <strong>Ethereal Tag</strong>


### PR DESCRIPTION
## Summary
- Removes "ALVL and" from the Crafting Info description in wizard step 6

The option was described as "Show ALVL and crafted ALVL on magic items" but it only shows crafted ALVL. This corrects the description to match the actual behavior.

## Test plan
- [ ] Open the Build My Filter wizard and proceed to step 6
- [ ] Verify the Crafting Info option now reads "Show crafted ALVL on magic items"

🤖 Generated with [Claude Code](https://claude.com/claude-code)