### PR TITLE
fix: add FILTLVL tooltip explaining wizard range

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -894,7 +894,7 @@
                 </optgroup>
               </select>
               <label class="preview-filtlvl-label">FILTLVL:
-                <select id="preview-filtlvl">
+                <select id="preview-filtlvl" title="Wizard-generated filters use levels 1-4. Higher levels are for custom filters.">
                   <option value="0">0 (Show All)</option>
                   <option value="1" selected>1</option>
                   <option value="2">2</option>


### PR DESCRIPTION
## Summary
- Adds a `title` tooltip to the `#preview-filtlvl` select element clarifying that wizard-generated filters use levels 1-4 and higher levels are for custom filters.

## Test plan
- [ ] Open editor.html preview pane, hover over FILTLVL dropdown and verify tooltip appears with the correct text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)