### PR TITLE
fix: add error state to author import download

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -79,6 +79,7 @@
             <div id="author-step-3" style="display:none">
               <div class="text-center" style="padding:2rem 0">
                 <p id="author-loading-msg">Downloading filter...</p>
+                <p id="author-error-msg" style="display:none;color:#ff4040">Failed to download filter. Please try again.</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Adds `#author-error-msg` paragraph hidden by default after the loading message in author-step-3
- Displays a red error message "Failed to download filter. Please try again." when shown by JS
- Provides a proper error state for the download step instead of silently failing

## Test plan
- [ ] Simulate a download failure in the author import flow
- [ ] Verify the error message element exists in the DOM
- [ ] Verify JS can toggle it visible on error and hide it on success/retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)