### PR TITLE
fix: clarify that grail requires manual rule insertion

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -921,7 +921,7 @@
           <div class="editor-pane" id="pane-grail" style="display:none">
             <div class="grail-header">
               <h3>Holy Grail Tracker</h3>
-              <p class="text-muted">Check off unique items as you find them. Unfound items will be highlighted in your filter.</p>
+              <p class="text-muted">Check off items as you find them, then use Insert Grail Rules to highlight unfound items in your filter.</p>
               <div class="grail-actions">
                 <button class="btn btn-primary" id="btn-grail-generate">Insert Grail Rules</button>
                 <button class="btn btn-secondary" id="btn-grail-update">Update Grail Rules</button>


### PR DESCRIPTION
## Summary
- Updates the Holy Grail tracker description to make clear that rules must be manually inserted

The previous text "Unfound items will be highlighted in your filter" implied automatic live sync. This change replaces it with text that references the "Insert Grail Rules" button, making it clear the user must trigger an update manually.

## Test plan
- [ ] Open the Holy Grail tab in the editor
- [ ] Verify the description now reads "Check off items as you find them, then use Insert Grail Rules to highlight unfound items in your filter."

🤖 Generated with [Claude Code](https://claude.com/claude-code)