### PR TITLE
fix: standardize visibility mechanism in filters.html

### DIFF
--- a/filters.html
+++ b/filters.html
@@ -45,7 +45,7 @@
       <div class="filter-grid" id="filter-grid"></div>
       <div class="filters-no-results hidden" id="filters-no-results" aria-live="polite">No filters match your search.</div>
       <div class="filters-loading" id="filters-loading" role="status">Loading filters...</div>
-      <div class="filters-error" id="filters-error" style="display:none;" role="alert">
+      <div class="filters-error hidden" id="filters-error" role="alert">
         Could not load filters. <a href="https://github.com/Project-Diablo-2/LootFilters" target="_blank" rel="noopener">View on GitHub</a>
       </div>
     </div>

--- a/js/filters.js
+++ b/js/filters.js
@@ -22,7 +22,7 @@
 
   function renderFilters(data) {
     filters = data;
-    loading.style.display = 'none';
+    loading.classList.add('hidden');
     grid.innerHTML = '';
 
     data.forEach(function (f, i) {
@@ -88,8 +88,8 @@
         })
         .then(renderFilters)
         .catch(function () {
-          loading.style.display = 'none';
-          errorEl.style.display = 'block';
+          loading.classList.add('hidden');
+          errorEl.classList.remove('hidden');
         });
     });
 })();


### PR DESCRIPTION
## Summary
- Changes `#filters-error` in `filters.html` from `style="display:none;"` to using the `hidden` class, matching the pattern used by `#filters-no-results`
- Updates `js/filters.js` to use `classList.add('hidden')` / `classList.remove('hidden')` instead of `style.display` for both the error element and the loading element

## Test plan
- [ ] Open filters.html and confirm the page loads filters correctly
- [ ] Simulate a network failure to verify the error message appears using the `hidden` class toggle
- [ ] Confirm the loading indicator hides correctly after data loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)