### PR TITLE
fix: initialize wizard progress bar at 0%

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -95,7 +95,7 @@
           <div class="modal-body">
             <!-- Progress bar -->
             <div class="wizard-progress">
-              <div class="wizard-progress-bar" id="wizard-progress-bar" style="width:10%"></div>
+              <div class="wizard-progress-bar" id="wizard-progress-bar" style="width:0%"></div>
             </div>
             <div class="wizard-step-label" id="wizard-step-label">Step 1 of 10</div>
 


### PR DESCRIPTION
## Summary
- Changes the wizard progress bar initial `style="width:10%"` to `style="width:0%"` so it starts empty before the user makes any selections.

## Test plan
- [ ] Open editor.html and launch the wizard — verify the progress bar starts at 0% width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)