### PR TITLE
fix: remove incorrect '3-char' from item code label

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -587,7 +587,7 @@
                   <button class="chip" data-value="!RW">!RW</button>
                 </div>
 
-                <label class="builder-label" for="item-code-input">Item Code (3-char)</label>
+                <label class="builder-label" for="item-code-input">Item Code</label>
                 <div class="itemcode-input-wrap">
                   <input type="text" class="builder-input" id="item-code-input" placeholder="Type name or code..." maxlength="20" autocomplete="off">
                   <div class="itemcode-dropdown" id="itemcode-dropdown"></div>


### PR DESCRIPTION
## Summary
- Changes the label for the item code input in `editor.html` from `Item Code (3-char)` to `Item Code`, since PD2 item codes are not always 3 characters

## Test plan
- [ ] Open `editor.html` and verify the item code label reads "Item Code" without the "(3-char)" suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)