### PR TITLE
fix: apply active class to current page nav link

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -25,7 +25,7 @@
       <li><a href="faq.html">FAQ</a></li>
       <li><a href="filters.html">Filters</a></li>
       <li><a href="guide.html">Guide</a></li>
-      <li><a href="editor.html">Editor</a></li>
+      <li><a href="editor.html" class="active">Editor</a></li>
     </ul>
     <a href="https://github.com/Maaaaaarrk/FilterForge/issues" target="_blank" rel="noopener" class="nav-issue-btn" title="Report an issue">Report Issue</a>
     <button class="nav-hamburger" aria-label="Toggle navigation" aria-controls="nav-links">&#9776;</button>

--- a/faq.html
+++ b/faq.html
@@ -22,7 +22,7 @@
     <a href="index.html" class="nav-logo"><img src="logo-nav.png" alt="Filter Forge" class="nav-logo-img"></a>
     <ul class="nav-links" id="nav-links">
       <li><a href="index.html">Home</a></li>
-      <li><a href="faq.html">FAQ</a></li>
+      <li><a href="faq.html" class="active">FAQ</a></li>
       <li><a href="filters.html">Filters</a></li>
       <li><a href="guide.html">Guide</a></li>
       <li><a href="editor.html">Editor</a></li>

--- a/filters.html
+++ b/filters.html
@@ -23,7 +23,7 @@
     <ul class="nav-links" id="nav-links">
       <li><a href="index.html">Home</a></li>
       <li><a href="faq.html">FAQ</a></li>
-      <li><a href="filters.html">Filters</a></li>
+      <li><a href="filters.html" class="active">Filters</a></li>
       <li><a href="guide.html">Guide</a></li>
       <li><a href="editor.html">Editor</a></li>
     </ul>

--- a/guide.html
+++ b/guide.html
@@ -24,7 +24,7 @@
       <li><a href="index.html">Home</a></li>
       <li><a href="faq.html">FAQ</a></li>
       <li><a href="filters.html">Filters</a></li>
-      <li><a href="guide.html">Guide</a></li>
+      <li><a href="guide.html" class="active">Guide</a></li>
       <li><a href="editor.html">Editor</a></li>
     </ul>
     <a href="https://github.com/Maaaaaarrk/FilterForge/issues" target="_blank" rel="noopener" class="nav-issue-btn" title="Report an issue">Report Issue</a>


### PR DESCRIPTION
## Summary
- Adds `class="active"` to the nav `<a>` link matching the current page in editor.html, guide.html, faq.html, and filters.html
- index.html is skipped as it uses the logo link rather than a standard nav entry

## Test plan
- [ ] Visit each page and verify the correct nav link is visually highlighted as active
- [ ] Confirm no nav links are marked active on index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)