### PR TITLE
fix: mention .txt in import button tooltip

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -41,7 +41,7 @@
         </div>
         <div class="toolbar-right">
           <button class="btn btn-secondary" id="btn-new" title="New filter">New</button>
-          <button class="btn btn-secondary" id="btn-import" title="Import .filter file from disk">Import File</button>
+          <button class="btn btn-secondary" id="btn-import" title="Import .filter or .txt file from disk">Import File</button>
           <button class="btn btn-secondary" id="btn-import-author" title="Import from a community filter author">Import from Community Author</button>
           <button class="btn btn-accent" id="btn-wizard" title="Answer questions to build a custom filter">Build My Filter</button>
           <button class="btn btn-primary" id="btn-export" title="Download as .filter file">Export .filter</button>


### PR DESCRIPTION
## Summary
- Updates the import button tooltip in `editor.html` from `Import .filter file from disk` to `Import .filter or .txt file from disk`
- The file input already accepts both `.filter` and `.txt`, so the tooltip should reflect that

## Test plan
- [ ] Open `editor.html` and hover over the "Import File" button to confirm the tooltip reads "Import .filter or .txt file from disk"

🤖 Generated with [Claude Code](https://claude.com/claude-code)