### PR TITLE
fix: add tooltips to notification chip labels

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -708,8 +708,8 @@
 
                   <label class="builder-label">Notification</label>
                   <div class="chip-group" data-field="notify">
-                    <button class="chip active" data-value="">Default</button>
-                    <button class="chip" data-value="%NOTIFY-DEAD%">Disable</button>
+                    <button class="chip active" data-value="" title="Use PD2's built-in notification behavior">Default</button>
+                    <button class="chip" data-value="%NOTIFY-DEAD%" title="Suppress built-in notifications for this rule">Disable</button>
                   </div>
 
                   <label class="builder-label">Continue</label>


### PR DESCRIPTION
## Summary
- Adds `title` tooltip attributes to the "Default" and "Disable" notification chip buttons in the rule builder, clarifying their behavior to users.

## Test plan
- [ ] Open editor.html rule builder, hover over "Default" notification chip and verify tooltip "Use PD2's built-in notification behavior" appears.
- [ ] Hover over "Disable" chip and verify tooltip "Suppress built-in notifications for this rule" appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)