### PR TITLE
fix: add aria-controls to FAQ search input

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -38,7 +38,7 @@
       </div>
 
       <div class="search-wrap">
-        <input type="text" class="search-input" id="faq-search" placeholder="Search questions, answers, and tags..." autocomplete="off" aria-label="Search FAQ">
+        <input type="text" class="search-input" id="faq-search" placeholder="Search questions, answers, and tags..." autocomplete="off" aria-label="Search FAQ" aria-controls="faq-result-count faq-container">
       </div>
       <div class="faq-result-count" id="faq-result-count" aria-live="polite"></div>
 


### PR DESCRIPTION
## Summary
- Adds `aria-controls="faq-result-count faq-container"` to the FAQ search input so assistive technologies can identify which regions are updated when the user types.

## Test plan
- [ ] Verify with a screen reader or accessibility audit that the FAQ search input correctly references the result count and container regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)