### PR TITLE
fix: enable sidebar scrolling with sticky position

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -120,6 +120,9 @@
   flex-shrink: 0;
   overflow-y: auto;
   padding-right: 0.5rem;
+  max-height: calc(100vh - 80px);
+  position: sticky;
+  top: 80px;
 }
 
 .sidebar-section h3 {


### PR DESCRIPTION
## Summary
- Adds `max-height: calc(100vh - 80px)` and `position: sticky; top: 80px` to `.editor-sidebar` so the sidebar sticks to the viewport and scrolls independently from the main content area.

## Test plan
- [ ] Open editor.html with a long rule list and verify the sidebar stays visible and scrolls independently while the main content scrolls normally.
- [ ] Confirm the mobile breakpoint override (`max-height: none`, `overflow-y: visible`) still works correctly on narrow screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)