### PR TITLE
fix: add initial aria-expanded to hamburger button

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -28,7 +28,7 @@
       <li><a href="editor.html">Editor</a></li>
     </ul>
     <a href="https://github.com/Maaaaaarrk/FilterForge/issues" target="_blank" rel="noopener" class="nav-issue-btn" title="Report an issue">Report Issue</a>
-    <button class="nav-hamburger" aria-label="Toggle navigation" aria-controls="nav-links">&#9776;</button>
+    <button class="nav-hamburger" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">&#9776;</button>
   </nav>
 
   <main class="main-content">

--- a/faq.html
+++ b/faq.html
@@ -28,7 +28,7 @@
       <li><a href="editor.html">Editor</a></li>
     </ul>
     <a href="https://github.com/Maaaaaarrk/FilterForge/issues" target="_blank" rel="noopener" class="nav-issue-btn" title="Report an issue">Report Issue</a>
-    <button class="nav-hamburger" aria-label="Toggle navigation" aria-controls="nav-links">&#9776;</button>
+    <button class="nav-hamburger" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">&#9776;</button>
   </nav>
 
   <main class="main-content">

--- a/filters.html
+++ b/filters.html
@@ -28,7 +28,7 @@
       <li><a href="editor.html">Editor</a></li>
     </ul>
     <a href="https://github.com/Maaaaaarrk/FilterForge/issues" target="_blank" rel="noopener" class="nav-issue-btn" title="Report an issue">Report Issue</a>
-    <button class="nav-hamburger" aria-label="Toggle navigation" aria-controls="nav-links">&#9776;</button>
+    <button class="nav-hamburger" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">&#9776;</button>
   </nav>
 
   <main class="main-content">

--- a/guide.html
+++ b/guide.html
@@ -28,7 +28,7 @@
       <li><a href="editor.html">Editor</a></li>
     </ul>
     <a href="https://github.com/Maaaaaarrk/FilterForge/issues" target="_blank" rel="noopener" class="nav-issue-btn" title="Report an issue">Report Issue</a>
-    <button class="nav-hamburger" aria-label="Toggle navigation" aria-controls="nav-links">&#9776;</button>
+    <button class="nav-hamburger" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">&#9776;</button>
   </nav>
 
   <main class="main-content">

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       <li><a href="editor.html">Editor</a></li>
     </ul>
     <a href="https://github.com/Maaaaaarrk/FilterForge/issues" target="_blank" rel="noopener" class="nav-issue-btn" title="Report an issue">Report Issue</a>
-    <button class="nav-hamburger" aria-label="Toggle navigation" aria-controls="nav-links">&#9776;</button>
+    <button class="nav-hamburger" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">&#9776;</button>
   </nav>
 
   <main class="main-content">


### PR DESCRIPTION
## Summary
- Adds `aria-expanded="false"` to the `.nav-hamburger` button in all 5 HTML pages: index.html, editor.html, guide.html, faq.html, and filters.html
- Provides correct initial ARIA state for screen readers before JavaScript sets the dynamic value

## Test plan
- [ ] Inspect each page's hamburger button and confirm `aria-expanded="false"` is present in the initial HTML
- [ ] Toggle the nav on mobile and verify JavaScript updates the attribute to `"true"` when open

🤖 Generated with [Claude Code](https://claude.com/claude-code)