### PR TITLE
fix: add viewport meta tag to splash.html

### DIFF
--- a/splash.html
+++ b/splash.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Filter Forge Splash</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }


### PR DESCRIPTION
## Summary
- Adds `<meta name="viewport" content="width=device-width, initial-scale=1.0">` to `splash.html`'s `<head>`, matching the pattern used by all other HTML pages in the project

## Test plan
- [ ] Open splash.html on a mobile device or browser devtools mobile emulator
- [ ] Verify the page renders at the correct device width without zooming out

🤖 Generated with [Claude Code](https://claude.com/claude-code)