### PR TITLE
fix: correct base colors for Worldstone Shard and Puzzlebox

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -2049,6 +2049,9 @@
     else if (item.flags.indexOf('MAG') !== -1) rarityColor = '#6464ff'; // blue
     else if (item.values && item.values.RUNE > 0) rarityColor = '#ff8000'; // orange for runes
     else if (item.flags.indexOf('NMAG') !== -1) rarityColor = '#ffffff'; // white
+    // PD2 special item base colors
+    if (item.code === 'wss' || item.code === 'cwss') rarityColor = '#ff4040'; // red for Worldstone Shard
+    else if (item.code === 'lbox' || item.code === 'lpp') rarityColor = '#c8a040'; // gold for Puzzlebox/Puzzlepiece
 
     var displayName;
     if (result.matched && result.output) {
@@ -2218,6 +2221,9 @@
     else if (item.flags.indexOf('MAG') !== -1) rarityColor = '#6464ff';
     else if (item.values && item.values.RUNE > 0) rarityColor = '#ff8000';
     else if (item.flags.indexOf('NMAG') !== -1) rarityColor = '#ffffff';
+    // PD2 special item base colors
+    if (item.code === 'wss' || item.code === 'cwss') rarityColor = '#ff4040'; // red for Worldstone Shard
+    else if (item.code === 'lbox' || item.code === 'lpp') rarityColor = '#c8a040'; // gold for Puzzlebox/Puzzlepiece
     var currentColor = rarityColor;
     var result = '';
     // Split by color tokens — but also handle adjacent tokens carefully
@@ -2784,8 +2790,8 @@
       // Worldstone Shard, Puzzlebox, Puzzlepiece
       lines.push('// --- Corruption & Crafting Materials ---');
       lines.push('ItemDisplay[wss]: %PURPLE%+ %RED%Worldstone Shard %PURPLE%+' + pd2BigNotify);
-      lines.push('ItemDisplay[lbox]: %PURPLE%+ %RED%Larzuks Puzzlebox %PURPLE%+' + pd2BigNotify);
-      lines.push('ItemDisplay[lpp]: %PURPLE%+ %RED%Larzuks Puzzlepiece %PURPLE%+' + pd2BigNotify);
+      lines.push('ItemDisplay[lbox]: %PURPLE%+ %GOLD%Larzuks Puzzlebox %PURPLE%+' + pd2BigNotify);
+      lines.push('ItemDisplay[lpp]: %PURPLE%+ %GOLD%Larzuks Puzzlepiece %PURPLE%+' + pd2BigNotify);
 
       // Skeleton Key
       lines.push('// --- Skeleton Key ---');


### PR DESCRIPTION
## Summary

- Worldstone Shard (`wss`/`cwss`) now renders in red (`#ff4040`) in the Live Preview default display
- Puzzlebox (`lbox`) and Puzzlepiece (`lpp`) now render in gold (`#c8a040`) in the Live Preview default display
- Wizard-generated filter rules for Puzzlebox and Puzzlepiece updated from `%RED%` to `%GOLD%` to match expected in-game appearance

Closes #93

## Test plan

- [ ] Open FilterForge without a loaded filter — verify Worldstone Shard appears red and Puzzlebox/Puzzlepiece appear gold in the preview item list
- [ ] Generate a new filter via the wizard — confirm the exported rules use `%RED%` for WSS and `%GOLD%` for Puzzlebox/Puzzlepiece
- [ ] Load the wizard-generated filter and verify the Live Preview renders WSS in red and Puzzlebox in gold

🤖 Generated with [Claude Code](https://claude.com/claude-code)