### PR TITLE
fix: mark description-only filter output as hidden in preview

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1814,7 +1814,7 @@
         return {
           matched: true,
           rule: rule,
-          hidden: finalOutput === '',
+          hidden: finalOutput === '' || !namePart.replace(/%[A-Z_0-9-]+%/g, '').trim(),
           output: finalOutput,
           continued: anyMatched,
           allRules: allMatchedRules
@@ -1826,7 +1826,8 @@
     if (anyMatched) {
       var finalOut = storedName;
       if (storedDesc) finalOut = storedName + '{' + storedDesc + '}';
-      return { matched: true, rule: lastRule, hidden: false, output: finalOut, continued: true, allRules: allMatchedRules };
+      var nameVisible = storedName.replace(/%[A-Z_0-9-]+%/g, '').trim();
+      return { matched: true, rule: lastRule, hidden: !nameVisible, output: finalOut, continued: true, allRules: allMatchedRules };
     }
     return { matched: false, hidden: false, output: '', rule: null, allRules: [] };
   }


### PR DESCRIPTION
## Summary

- Filter rules that output only `{tooltip text}` with no visible ground name were incorrectly shown as visible items in the preview
- Root cause: `matchItem()` only set `hidden: true` when `finalOutput` was completely empty, missing the case where `namePart` has no actual text (only tooltip content in braces)
- The CONTINUE-only fallback path had the same issue with `hidden: false` unconditionally

## Changes

- In the terminal-rule return path (`matchItem()` line ~1817): changed `hidden` check to also detect when `namePart` stripped of all `%TOKEN%` patterns is empty — meaning no visible ground text exists
- In the CONTINUE-only fallback path (line ~1829): applied the same token-stripping check against `storedName` instead of hardcoding `hidden: false`

## Test plan

- [ ] Create a filter rule like `ItemDisplay[GOLD]: {Some tooltip}` (no name before the braces)
- [ ] Preview a matching item — it should appear as hidden/filtered, not as a visible item
- [ ] Verify rules with actual visible text (e.g. `ItemDisplay[GOLD]: Gold`) still show as visible
- [ ] Verify rules with color tokens + text (e.g. `ItemDisplay[GOLD]: %YELLOW%Gold`) still show as visible

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)