### PR TITLE
fix: show tooltip descriptions in preview to distinguish items

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -2206,8 +2206,12 @@
       return lookup[code] || '';
     });
 
-    // Remove descriptions {} for inline display
-    text = text.replace(/\{[^}]*\}/g, '');
+    // Extract descriptions {} for display as dimmed suffix
+    var descriptions = [];
+    text = text.replace(/\{([^}]*)\}/g, function(m, desc) {
+      if (desc.trim()) descriptions.push(desc);
+      return '';
+    });
 
     // Convert colors to spans — start with item's rarity color
     var rarityColor = '#ffffff'; // default white
@@ -2251,6 +2255,10 @@
       if (chunk) {
         result += '<span style="color:' + currentColor + '">' + escapeHtml(chunk) + '</span>';
       }
+    }
+
+    if (descriptions.length) {
+      result += ' <span style="color:#888;font-size:0.85em">{' + escapeHtml(descriptions.join(' | ')) + '}</span>';
     }
 
     return result || escapeHtml(item.name);


### PR DESCRIPTION
## Summary

- Items that differ only by `{tooltip text}` content (e.g. two Grand Charms with different iLvl values) looked visually identical in the filter preview because `{...}` descriptions were stripped entirely from the rendered output.
- The `renderOutput()` function now extracts description content from `{...}` blocks and appends it as a dimmed (`color:#888`) suffix at 85% font size, so distinguishing metadata is visible in the preview.
- This fixes Kryszard's filter where two Grand Charms showed the same label despite having different ILVL-conditional CONTINUE chain outputs.

## Test plan

- [ ] Load Kryszard's filter and open the filter preview
- [ ] Confirm the two Grand Charm preview items now show distinct labels (e.g. one with `{iLvl: 91}` suffix and one without, or with a different suffix)
- [ ] Confirm the description suffix renders as dimmed gray text and does not affect the main colored name display
- [ ] Verify items without `{...}` descriptions are unaffected

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)