### PR TITLE
revert: remove description suffix from preview + change GC ilvl to 99

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -838,7 +838,7 @@
                   <option value="mag-ring">Magic Ring (rin)</option>
                   <option value="mag-amu">Magic Amulet (amu)</option>
                   <option value="mag-jewel">Magic Jewel (jew)</option>
-                  <option value="mag-gc-91">Magic GC ilvl91 (cm3)</option>
+                  <option value="mag-gc-99">Magic GC ilvl99 (cm3)</option>
                   <option value="mag-gc">Magic Grand Charm (cm3)</option>
                   <option value="mag-sc">Magic Small Charm (cm1)</option>
                   <option value="mag-lc">Magic Large Charm (cm2)</option>

--- a/js/editor.js
+++ b/js/editor.js
@@ -303,7 +303,7 @@
     'mag-ring': { code: 'rin', name: 'Ring', flags: ['GROUND', 'MAG', 'JEWELRY'], values: { ILVL: 45, SOCKETS: 0, RUNE: 0, GOLD: 0, GEM: 0 } },
     'mag-amu': { code: 'amu', name: 'Amulet', flags: ['GROUND', 'MAG', 'JEWELRY'], values: { ILVL: 85, CRAFTALVL: 90, SOCKETS: 0, RUNE: 0, GOLD: 0, GEM: 0 } },
     'mag-jewel': { code: 'jew', name: 'Jewel', flags: ['GROUND', 'MAG', 'JEWELRY'], values: { ILVL: 87, SOCKETS: 0, RUNE: 0, GOLD: 0, GEM: 0 } },
-    'mag-gc-91': { code: 'cm3', name: 'Grand Charm', flags: ['GROUND', 'MAG', 'CHARM'], values: { ILVL: 91, SOCKETS: 0, RUNE: 0, GOLD: 0, GEM: 0 } },
+    'mag-gc-99': { code: 'cm3', name: 'Grand Charm', flags: ['GROUND', 'MAG', 'CHARM'], values: { ILVL: 99, SOCKETS: 0, RUNE: 0, GOLD: 0, GEM: 0 } },
     'mag-gc': { code: 'cm3', name: 'Grand Charm', flags: ['GROUND', 'MAG', 'CHARM'], values: { ILVL: 50, SOCKETS: 0, RUNE: 0, GOLD: 0, GEM: 0 } },
     'mag-sc': { code: 'cm1', name: 'Small Charm', flags: ['GROUND', 'MAG', 'CHARM'], values: { ILVL: 50, SOCKETS: 0, RUNE: 0, GOLD: 0, GEM: 0 } },
     'mag-lc': { code: 'cm2', name: 'Large Charm', flags: ['GROUND', 'MAG', 'CHARM'], values: { ILVL: 50, SOCKETS: 0, RUNE: 0, GOLD: 0, GEM: 0 } },
@@ -2210,12 +2210,8 @@
       return lookup[code] || '';
     });
 
-    // Extract descriptions {} for display as dimmed suffix
-    var descriptions = [];
-    text = text.replace(/\{([^}]*)\}/g, function(m, desc) {
-      if (desc.trim()) descriptions.push(desc);
-      return '';
-    });
+    // Remove descriptions {} for inline display
+    text = text.replace(/\{[^}]*\}/g, '');
 
     // Convert colors to spans — start with item's rarity color
     var rarityColor = '#ffffff'; // default white
@@ -2262,10 +2258,6 @@
       if (chunk) {
         result += '<span style="color:' + currentColor + '">' + escapeHtml(chunk) + '</span>';
       }
-    }
-
-    if (descriptions.length) {
-      result += ' <span style="color:#888;font-size:0.85em">{' + escapeHtml(descriptions.join(' | ')) + '}</span>';
     }
 
     return result || escapeHtml(item.name);


### PR DESCRIPTION
## Summary
- Reverts the dimmed `{description}` suffix rendering from PR #130 — descriptions are stripped from inline preview display again
- Changes the grand charm preview example from ilvl 91 to ilvl 99

## Changes
- `js/editor.js`: Restored original `text.replace(/\{[^}]*\}/g, '')` in `renderOutput()`, removing the `descriptions[]` array and appended suffix span
- `js/editor.js`: Changed `mag-gc-91` preview item ILVL from 91 to 99
- `editor.html`: Updated dropdown option label to match (`mag-gc-99`, "Magic GC ilvl99")

🤖 Generated with [Claude Code](https://claude.com/claude-code)