### PR TITLE
Add missing Google Analytics tags

### DIFF
--- a/splash.html
+++ b/splash.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-MFHSCHGQ9Y"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-MFHSCHGQ9Y');
+</script>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Filter Forge Splash</title>
 <style>

--- a/test-color.html
+++ b/test-color.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MFHSCHGQ9Y"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MFHSCHGQ9Y');
+  </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Color Parser Test — Filter Forge</title>
   <style>


### PR DESCRIPTION
## Summary
- Add GA4 tag (G-MFHSCHGQ9Y) to `splash.html` and `test-color.html`
- These were the only two HTML files in the repo missing the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)