### PR TITLE
Fix #149: Ensure DOT, BORDER, MAP, PX always include a color code

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -723,7 +723,7 @@
 
                   <label class="builder-label" for="map-icon-color">Map Icon Color (hex)</label>
                   <a href="https://wiki.projectdiablo2.com/wiki/File:MapNotificationColors.png" target="_blank" rel="noopener" class="builder-hint-link">Color chart reference &rarr;</a>
-                  <input type="text" class="builder-input" id="map-icon-color" placeholder="e.g. 0A, FF, 1F (optional)" maxlength="2">
+                  <input type="text" class="builder-input" id="map-icon-color" placeholder="e.g. 0A, FF, 1F (defaults to FF)" maxlength="2">
 
                   <label class="builder-label" for="sound-select">Sound</label>
                   <p class="text-muted builder-hint">To hear sounds in-game: type <code>/sound XXXX</code> in chat (e.g. <code>/sound 4716</code>)</p>

--- a/js/editor.js
+++ b/js/editor.js
@@ -677,12 +677,10 @@
       }
 
       if (mapIcon) {
-        if (mapIconColor) {
-          var iconBase = mapIcon.replace(/%/g, '');
-          output += '%' + iconBase + '-' + mapIconColor + '%';
-        } else {
-          output += mapIcon;
-        }
+        var iconBase = mapIcon.replace(/%/g, '');
+        // BORDER, MAP, DOT, PX require a color code — default to FF if none given
+        var effectiveColor = mapIconColor || 'FF';
+        output += '%' + iconBase + '-' + effectiveColor + '%';
       }
 
       if (sound) {
@@ -857,6 +855,8 @@
         var baseTok = tok.replace(/-.*/, '');
         if (KNOWN_OUTPUT_TOKENS.indexOf(baseTok) !== -1) return m;
         // Notification tokens (BORDER-XX, MAP-XX, DOT-XX, SOUNDID-XXXX, etc.)
+        // Warn if BORDER/MAP/DOT/PX is used without a color code (e.g. %BORDER% instead of %BORDER-FF%)
+        if (/^(BORDER|MAP|DOT|PX)$/.test(tok)) return '<span class="hl-warn" title="' + m + ' requires a color code (e.g. %' + tok + '-FF%)">' + m + '</span>';
         if (/^(BORDER|MAP|DOT|PX|SOUNDID|SOUND|NOTIFY|TIER|STAT\d+|SK\d+|CLSK\d+|TABSK\d+|MULTI)/.test(tok)) return m;
         // Escaped percent
         if (tok === '') return m;


### PR DESCRIPTION
Closes #149

## Summary
- The filter builder was outputting bare tokens like `%BORDER%` or `%DOT%` when no color hex was entered in the Map Icon Color field. These bare tokens don't work in PD2 — a color code is required (e.g. `%BORDER-FF%`).
- Now defaults to `FF` (white) when no color is specified, so the output is always valid.
- Added an editor syntax warning highlight for bare BORDER/MAP/DOT/PX tokens missing a color code, helping users catch the issue in hand-written filters too.
- Updated the placeholder text to say "defaults to FF" instead of "optional".

## Test plan
- [ ] Open the filter builder, select a Map Icon (Border, Map, Dot, Pixel) without entering a color code — verify the generated rule uses `-FF` suffix
- [ ] Enter a custom color code (e.g. `0A`) — verify it uses that color instead
- [ ] In the code editor, type `%BORDER%` without a color code — verify it shows a warning highlight
- [ ] Verify the wizard-generated filters still produce correct notification tokens

Generated with [Claude Code](https://claude.com/claude-code)