### PR TITLE
Fix #148: Correct item tier mappings for base tree lookups

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -500,29 +500,41 @@
     // Belts
     ['lbl','zlb','ulc'],['vbl','zvb','uvc'],['mbl','zmb','umc'],['tbl','ztb','utc'],['hbl','zhb','uhc'],
     // Axes
-    ['hax','9ha','7wa'],['axe','9ax','72a'],['2ax','92a','72a'],['mpi','9mp','7bt'],['wax','9wa','7ga'],['lax','9la','7gi'],['bax','9ba','7la'],['btx','9bt','7bt'],['gax','9ga','7ga'],['gix','9gi','7gi'],
+    ['hax','9ha','7ha'],['axe','9ax','7ax'],['2ax','92a','72a'],['mpi','9mp','7mp'],['wax','9wa','7wa'],['lax','9la','7la'],['bax','9ba','7ba'],['btx','9bt','7bt'],['gax','9ga','7ga'],['gix','9gi','7gi'],
     // Maces
-    ['clb','9cl','7wh'],['spc','9sp','7wh'],['mac','9ma','7m7'],['mst','9mt','7m7'],['fla','9fl','7gm'],['whm','9wh','7wh'],['mau','9m9','7m7'],['gma','9gm','7gm'],
+    ['clb','9cl','7cl'],['spc','9sp','7sp'],['mac','9ma','7ma'],['mst','9mt','7mt'],['fla','9fl','7fl'],['whm','9wh','7wh'],['mau','9m9','7m7'],['gma','9gm','7gm'],
     // Swords
-    ['ssd','9ss','7cr'],['scm','9sm','7cr'],['sbr','9sb','7fb'],['flc','9fc','7fb'],['crs','9cr','7cr'],['bsd','9bs','7ls'],['lsd','9ls','7ls'],['wsd','9wd','7gd'],['2hs','92h','7fb'],['clm','9cm','7gd'],['gis','9gs','7gd'],['bsw','9b9','7gd'],['flb','9fb','7fb'],['gsd','9gd','7gd'],
+    ['ssd','9ss','7ss'],['scm','9sm','7sm'],['sbr','9sb','7sb'],['flc','9fc','7fc'],['crs','9cr','7cr'],['bsd','9bs','7bs'],['lsd','9ls','7ls'],['wsd','9wd','7wd'],['2hs','92h','72h'],['clm','9cm','7cm'],['gis','9gs','7gs'],['bsw','9b9','7b7'],['flb','9fb','7fb'],['gsd','9gd','7gd'],
     // Daggers
     ['dgr','9dg','7dg'],['dir','9di','7di'],['kri','9kr','7kr'],['bld','9bl','7bl'],
     // Spears
-    ['spr','9sr','7s7'],['tri','9tr','7s7'],['brn','9br','7s7'],['spt','9st','7p7'],['pik','9p9','7p7'],
+    ['spr','9sr','7sr'],['tri','9tr','7tr'],['brn','9br','7br'],['spt','9st','7st'],['pik','9p9','7p7'],
     // Polearms
-    ['bar','9b7','7pa'],['vou','9vo','7pa'],['scy','9s8','7s8'],['pax','9pa','7pa'],['hal','9h9','7p7'],['wsc','9wc','7s8'],
+    ['bar','9b7','7o7'],['vou','9vo','7vo'],['scy','9s8','7s8'],['pax','9pa','7pa'],['hal','9h9','7h7'],['wsc','9wc','7wc'],
     // Javelins
-    ['jav','9ja','7ja'],['pil','9pi','7pi'],['ssp','9s9','7s9'],['glv','9gl','7gl'],['tsp','9ts','7ts'],
+    ['jav','9ja','7ja'],['pil','9pi','7pi'],['ssp','9s9','7s7'],['glv','9gl','7gl'],['tsp','9ts','7ts'],
     // Throwing
     ['tkf','9tk','7tk'],['tax','9ta','7ta'],['bkf','9bk','7bk'],['bal','9b8','7b8'],
     // Bows
-    ['sbw','9sb','6lw'],['hbw','9lw','6sw'],['lbw','9sw','6lw'],['cbw','9cb','6lw'],
+    ['sbw','8sb','6sb'],['hbw','8hb','6hb'],['lbw','8lb','6lb'],['cbw','8cb','6cb'],['sbb','8s8','6s7'],['lbb','8l8','6l7'],['swb','8sw','6sw'],['lwb','8lw','6lw'],
     // Crossbows
-    ['lxb','9lx','6mx'],['mxb','9mx','6mx'],['hxb','9hx','6rx'],['rxb','9rx','6rx'],
+    ['lxb','8lx','6lx'],['mxb','8mx','6mx'],['hxb','8hx','6hx'],['rxb','8rx','6rx'],
     // Staves
-    ['sst','9ss','6ws'],['lst','9ls','6ls'],['cst','9cs','6cs'],['bst','9bs','6bs'],['wst','9ws','6ws'],
+    ['sst','8ss','6ss'],['lst','8ls','6ls'],['cst','8cs','6cs'],['bst','8bs','6bs'],['wst','8ws','6ws'],
     // Scepters
-    ['scp','9qs','7ws'],['gsc','9sc','7ws'],['wsp','9ws','7ws']
+    ['scp','9qs','7qs'],['gsc','9sc','7sc'],['wsp','9ws','7ws'],
+    // Assassin Katars
+    ['ktr','9ar','7ar'],['wrb','9wb','7wb'],['axf','9xf','7xf'],['ces','9cs','7cs'],['clw','9lw','7lw'],['btl','9tw','7tw'],['skr','9qr','7qr'],
+    // Amazon Bows
+    ['am1','am6','amb'],['am2','am7','amc'],
+    // Amazon Spears/Pikes/Javelins
+    ['am3','am8','amd'],['am4','am9','ame'],['am5','ama','amf'],
+    // Druid Pelts
+    ['dr1','dr6','drb'],['dr2','dr7','drc'],['dr3','dr8','drd'],['dr4','dr9','dre'],['dr5','dra','drf'],
+    // Barbarian Helms
+    ['ba1','ba6','bab'],['ba2','ba7','bac'],['ba3','ba8','bad'],['ba4','ba9','bae'],['ba5','baa','baf'],
+    // Paladin Shields
+    ['pa1','pa6','pab'],['pa2','pa7','pac'],['pa3','pa8','pad'],['pa4','pa9','pae'],['pa5','paa','paf']
   ];
   var ITEM_TIER_MAP = {};
   ITEM_TIER_GROUPS.forEach(function (group) {


### PR DESCRIPTION
Closes #148

## Summary
- The ITEM_TIER_GROUPS table that powers the "add all 3 versions" checkbox in the filter builder had widespread incorrect elite item codes. Many weapon types shared the same elite code instead of mapping to their correct tier equivalent.
- Examples from the issue: Scourge (7fl) was mapped to Thunder Maul's group, Devil Star (7mt) was mapped to Ogre Maul's group, and War Fist (7xf) was missing entirely since class items had no tier entries.
- Fixed incorrect elite codes across axes (6 of 10 wrong), maces (5 of 8 wrong), swords (10 of 14 wrong), spears (4 of 5 wrong), polearms (4 of 6 wrong), javelins (1 wrong), scepters (2 of 3 wrong).
- Fixed bow and crossbow exceptional codes (should use 8-prefix, not 9-prefix) and elite codes. Added 4 missing bow types (Short/Long Battle Bow, Short/Long War Bow).
- Fixed staff exceptional codes (should use 8-prefix, not 9-prefix) and corrected Short Staff elite code.
- Added all missing class item tier groups: Assassin Katars (7 items), Amazon Bows/Spears/Pikes/Javelins (5 groups), Druid Pelts (5), Barbarian Helms (5), Paladin Shields (5).

## Test plan
- [ ] In the filter builder, enter item code `7fl` (Scourge), check "All 3 versions" — verify it produces `(fla OR 9fl OR 7fl)`
- [ ] Enter `7mt` (Devil Star) with all tiers — verify `(mst OR 9mt OR 7mt)`
- [ ] Enter `7xf` (War Fist) with all tiers — verify `(axf OR 9xf OR 7xf)`
- [ ] Enter `crs` (Crystal Sword) — verify `(crs OR 9cr OR 7cr)` (unchanged, was already correct)
- [ ] Enter `sbw` (Short Bow) — verify `(sbw OR 8sb OR 6sb)` (new correct mapping)
- [ ] Enter `drb` (Blood Spirit druid pelt) — verify `(dr1 OR dr6 OR drb)` (newly added class items)
- [ ] Spot-check a few more categories to confirm correctness

Generated with [Claude Code](https://claude.com/claude-code)