### PR TITLE
Add eth variants for magic and rare in all items display

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -5463,6 +5463,40 @@
       });
     });
 
+    // Generate ETH variants for MAG items (equipment only, not jewelry/charms)
+    var magEthSkip = ['rin', 'amu', 'jew', 'cm1', 'cm2', 'cm3'];
+    var magBases = items.filter(function (it) {
+      return it.cat === 'mag' && magEthSkip.indexOf(it.code) === -1 &&
+        it.flags.indexOf('ETH') === -1 &&
+        it.flags.indexOf('MISC') === -1 && it.flags.indexOf('CHARM') === -1 &&
+        it.flags.indexOf('JEWELRY') === -1;
+    });
+    magBases.forEach(function (base) {
+      var ethFlags = base.flags.slice();
+      ethFlags.push('ETH');
+      items.push({
+        key: base.key + '-eth', code: base.code, name: 'Eth ' + base.name,
+        flags: ethFlags, values: Object.assign({}, base.values), cat: 'mag', hasFullData: false
+      });
+    });
+
+    // Generate ETH variants for RARE items (equipment only, not jewelry)
+    var rareEthSkip = ['rin', 'amu', 'jew'];
+    var rareBases = items.filter(function (it) {
+      return it.cat === 'rare' && rareEthSkip.indexOf(it.code) === -1 &&
+        it.flags.indexOf('ETH') === -1 &&
+        it.flags.indexOf('MISC') === -1 &&
+        it.flags.indexOf('JEWELRY') === -1;
+    });
+    rareBases.forEach(function (base) {
+      var ethFlags = base.flags.slice();
+      ethFlags.push('ETH');
+      items.push({
+        key: base.key + '-eth', code: base.code, name: 'Eth ' + base.name,
+        flags: ethFlags, values: Object.assign({}, base.values), cat: 'rare', hasFullData: false
+      });
+    });
+
     return items;
   }
 


### PR DESCRIPTION
## Summary
- Adds ethereal (ETH) variant generation for **magic** and **rare** equipment items in the "All Items" display
- Previously, only non-magic (NMAG) items had ETH variants generated; magic and rare equipment were missing them
- Skips items that cannot be ethereal (jewelry, charms, misc items)

Closes #152

## Test plan
- [ ] Open the editor and go to the "All Items" view
- [ ] Select the "Magic" category and verify ethereal variants appear (e.g., "Eth Archon Plate", "Eth Monarch")
- [ ] Select the "Rare" category and verify ethereal variants appear
- [ ] Confirm jewelry (rings, amulets, jewels) and charms do NOT have eth variants
- [ ] Verify filter rules matching ETH + MAG or ETH + RARE correctly highlight these items

🤖 Generated with [Claude Code](https://claude.com/claude-code)