### PR TITLE
fix: include grail textarea in highlightAllCommunityTAs

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -950,6 +950,7 @@
     highlightCommunityTA('community-top-block');
     highlightCommunityTA('community-filter-text');
     highlightCommunityTA('community-bottom-block');
+    highlightCommunityTA('community-grail-text');
   }
 
   function syncScroll() {


### PR DESCRIPTION
## Summary

- `highlightAllCommunityTAs()` was missing a call to highlight the `community-grail-text` textarea
- When community mode is restored from localStorage with an existing grail section, the grail textarea rendered without syntax highlighting until the user manually toggled its visibility (hide → show)
- The mapping for `community-grail-text` → `community-grail-hl` was already defined in `highlightCommunityTA()` — it just wasn't being called from `highlightAllCommunityTAs()`

## Test plan

- [ ] Enable community edit mode and insert grail rules so the grail section has content
- [ ] Reload the page — community mode should restore automatically
- [ ] Verify the grail section shows syntax highlighting immediately on restore (without needing to toggle Hide/Show)

🤖 Generated with [Claude Code](https://claude.com/claude-code)