### PR TITLE
fix: reset builderState.location when clearing the rule builder

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -2554,6 +2554,7 @@
       builderState.weapons = '';
       builderState.misc = '';
       builderState.classitems = '';
+      builderState.location = [];
       builderState.negate = [];
       builderState.action = 'show';
       builderState.nameDisplay = '%NAME%';


### PR DESCRIPTION
## Summary

- The Clear Builder button (`btn-clear-builder`) was correctly removing the `active` CSS class from location chips (Ground / Equipped) in the UI
- But it never reset `builderState.location = []` — every other state field was reset, but `location` was skipped
- Result: after clearing, the old location condition silently persisted in state. The next time the user clicked any chip to build a new rule, `updateGeneratedRule()` would run and inject the stale location (e.g. `GROUND`) into the new rule — even though no location chip was visually selected

## Test plan

- [ ] Select "Ground" from the Location chip group in the rule builder
- [ ] Click "Clear Builder"
- [ ] Click any quality chip (e.g. Unique) to trigger rule generation
- [ ] Verify `GROUND` does **not** appear in the generated rule (it did before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)