### PR TITLE
fix: exit community mode when importing a file from disk

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1084,6 +1084,12 @@
         if (text.indexOf('\uFFFD') !== -1) {
           text = new TextDecoder('windows-1252').decode(buf);
         }
+        if (communityMode.active) {
+          communityMode.active = false;
+          saveCommunityState();
+          document.getElementById('pane-community').style.display = 'none';
+          document.getElementById('pane-code').style.display = 'block';
+        }
         codeEditor.value = text;
         updateLineNumbers();
         saveToStorage();


### PR DESCRIPTION
## Summary

- Importing a `.filter` file via "Import File" while in community mode wrote the text into the hidden `codeEditor` but left the community panel active and visible
- The next call to `getFullFilterText()` reassembled the community blocks, silently discarding the imported text
- The "New" button already handles this correctly by exiting community mode before clearing the editor — this applies the same pattern to the file import handler

## Test plan

- [ ] Enter community mode (import a community filter from any author)
- [ ] Click "Import File" and select a `.filter` file from disk
- [ ] Verify the community panel closes and the imported filter appears in the full code editor
- [ ] Verify the imported text persists after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)