### PR TITLE
feat: import grail data from ?graildata= URL parameter

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -865,6 +865,12 @@
   font-size: 0.82rem;
 }
 
+.grail-import-notice.empty {
+  background: #3a321a;
+  border-color: #8a7a4a;
+  color: #e0cc88;
+}
+
 .grail-category {
   margin-bottom: 0.75rem;
 }

--- a/css/editor.css
+++ b/css/editor.css
@@ -855,6 +855,16 @@
   padding: 0.5rem 1rem;
 }
 
+.grail-import-notice {
+  margin: 0.5rem 1rem 0;
+  padding: 0.5rem 0.85rem;
+  border-radius: 6px;
+  background: #1a3a1a;
+  border: 1px solid #4a8a4a;
+  color: #aaffaa;
+  font-size: 0.82rem;
+}
+
 .grail-category {
   margin-bottom: 0.75rem;
 }

--- a/js/editor.js
+++ b/js/editor.js
@@ -1519,11 +1519,13 @@
       var params = new URLSearchParams(window.location.search);
       var grailParam = params.get('graildata');
       if (!grailParam) return;
+      if (grailParam.length > 100000) return;
       try {
         var payload = JSON.parse(atob(grailParam));
         if (!Array.isArray(payload.found)) return;
-        // Build reverse lookup: item name -> categories it appears in
-        var nameMap = {};
+        // Object.create(null) so payload entries like "__proto__" or "toString"
+        // don't hit inherited properties and short-circuit the import.
+        var nameMap = Object.create(null);
         Object.keys(GRAIL_DATA).forEach(function (cat) {
           GRAIL_DATA[cat].forEach(function (item) {
             if (!nameMap[item.name]) nameMap[item.name] = [];
@@ -1542,14 +1544,16 @@
         if (count > 0) saveGrail();
         params.delete('graildata');
         history.replaceState(null, '', window.location.pathname + (params.toString() ? '?' + params.toString() : '') + window.location.hash);
-        if (count > 0) {
-          var notice = document.createElement('div');
-          notice.className = 'grail-import-notice';
-          notice.textContent = '\u2713 ' + count + ' item' + (count !== 1 ? 's' : '') + ' imported from Project Grail';
-          grailList.insertAdjacentElement('beforebegin', notice);
-          setTimeout(function () { if (notice.parentNode) notice.parentNode.removeChild(notice); }, 6000);
-        }
-      } catch (e) {}
+        var notice = document.createElement('div');
+        notice.className = count > 0 ? 'grail-import-notice' : 'grail-import-notice empty';
+        notice.textContent = count > 0
+          ? '\u2713 ' + count + ' item' + (count !== 1 ? 's' : '') + ' imported from Project Grail'
+          : 'No matching items in imported grail data';
+        grailList.insertAdjacentElement('beforebegin', notice);
+        setTimeout(function () { if (notice.parentNode) notice.parentNode.removeChild(notice); }, 6000);
+      } catch (e) {
+        console.warn('Grail import failed', e);
+      }
     }());
 
     renderGrail('');

--- a/js/editor.js
+++ b/js/editor.js
@@ -1513,6 +1513,45 @@
       if (el) el.addEventListener(el.tagName === 'SELECT' ? 'change' : 'input', updateGrailPreview);
     });
 
+    // Import grail data from ?graildata= URL parameter (e.g. from pd2grail.com).
+    // Payload: base64(JSON.stringify({ found: ["ItemName", ...] }))
+    (function () {
+      var params = new URLSearchParams(window.location.search);
+      var grailParam = params.get('graildata');
+      if (!grailParam) return;
+      try {
+        var payload = JSON.parse(atob(grailParam));
+        if (!Array.isArray(payload.found)) return;
+        // Build reverse lookup: item name -> categories it appears in
+        var nameMap = {};
+        Object.keys(GRAIL_DATA).forEach(function (cat) {
+          GRAIL_DATA[cat].forEach(function (item) {
+            if (!nameMap[item.name]) nameMap[item.name] = [];
+            nameMap[item.name].push(cat);
+          });
+        });
+        var count = 0;
+        payload.found.forEach(function (name) {
+          var cats = nameMap[name];
+          if (!cats) return;
+          cats.forEach(function (cat) {
+            var key = cat + ':' + name;
+            if (!found[key]) { found[key] = true; count++; }
+          });
+        });
+        if (count > 0) saveGrail();
+        params.delete('graildata');
+        history.replaceState(null, '', window.location.pathname + (params.toString() ? '?' + params.toString() : '') + window.location.hash);
+        if (count > 0) {
+          var notice = document.createElement('div');
+          notice.className = 'grail-import-notice';
+          notice.textContent = '\u2713 ' + count + ' item' + (count !== 1 ? 's' : '') + ' imported from Project Grail';
+          grailList.insertAdjacentElement('beforebegin', notice);
+          setTimeout(function () { if (notice.parentNode) notice.parentNode.removeChild(notice); }, 6000);
+        }
+      } catch (e) {}
+    }());
+
     renderGrail('');
     updateGrailPreview();
   }


### PR DESCRIPTION
## Summary

Adds support for pre-populating the Holy Grail checklist via a base64-encoded `?graildata=` URL parameter. This enables external grail trackers (e.g. [pd2grail.com](https://pd2grail.com)) to send a user directly to the editor with their found items already checked off.

**Payload format:**
```
?graildata=<base64(JSON.stringify({ found: ["Shako", "Griffon's Eye", ...] }))>
```

Item names must match the display names already in `GRAIL_DATA` (e.g. `"Shako"` not `"Harlequin Crest"`). pd2grail.com normalizes names to match FilterForge's scheme before encoding.

**On page load, if `?graildata=` is present:**
1. Decodes and parses the payload
2. Marks matching items as found — merges with existing localStorage state, never overwrites unchecked items
3. Saves merged state to localStorage
4. Cleans the URL (removes the param via `history.replaceState`)
5. Shows a brief green confirmation notice above the grail list for 6 seconds

**Changes:**
- `js/editor.js` — IIFE inserted just before `renderGrail('')` at the end of `initGrail()`
- `css/editor.css` — `.grail-import-notice` style (green banner, auto-dismissed)

The existing grail localStorage state is always preserved — import only adds found entries, never removes them.