### PR TITLE
fix: correct Amazon staffmod skill IDs

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -4107,15 +4107,15 @@
       });
 
       // Individual skill staffmods — data: [SK#, name, top] where top=true means show at all FILTLVL
-      // Amazon
+      // Amazon — IDs and names per PD2 wiki + SKILL_DATA (engine IDs are interleaved across tabs, not sequential)
       var aznSkills = [
-        ['SK6','MagicArw',0],['SK7','FireArw',0],['SK8','ColdArw',0],['SK9','MultShot',0],['SK10','ExplArw',0],
-        ['SK11','IceArw',1],['SK12','GuidArw',1],['SK13','Strafe',1],['SK14','Immolation',1],
-        ['SK16','InnerSight',0],['SK17','CritStrike',0],['SK18','Dodge',0],['SK19','SlwMissle',0],
-        ['SK20','Avoid',0],['SK21','Penetrate',0],['SK22','Decoy',0],['SK23','Evade',0],
-        ['SK24','Valkyrie',1],['SK25','Pierce',1],
-        ['SK26','Jab',0],['SK27','PwrStrk',0],['SK28','PoisJav',0],['SK29','Impale',0],
-        ['SK30','LghtBolt',0],['SK31','ChrgStrk',1],['SK32','PlgJav',1],['SK33','Fend',0],
+        ['SK6','MagicArw',0],['SK7','FireArw',0],['SK8','InnerSight',0],['SK9','CritStrike',0],
+        ['SK10','Jab',0],['SK11','ColdArw',0],['SK12','MultShot',0],['SK13','Dodge',0],
+        ['SK14','PwrStrk',0],['SK15','PoisJav',0],['SK16','ExplArw',0],['SK17','SlwMissle',0],
+        ['SK18','Avoid',0],['SK19','JavMstry',0],['SK20','LghtBolt',0],['SK21','IceArw',1],
+        ['SK22','GuidArw',1],['SK23','Penetrate',0],['SK24','ChrgStrk',1],['SK25','PlgJav',1],
+        ['SK26','Strafe',1],['SK27','Immolation',1],['SK28','Decoy',0],['SK29','Evade',0],
+        ['SK30','Fend',0],['SK31','FrzArw',1],['SK32','Valkyrie',1],['SK33','Pierce',1],
         ['SK34','LghtStrk',1],['SK35','LghtFury',1]
       ];
       // Sorceress — IDs and names per PD2 wiki + HiimFilter staffmod upstream


### PR DESCRIPTION
## Summary

Fixes the Amazon class staffmod skill array (`aznSkills` in `js/editor.js`), which used the same "tree-sequential" mental model — assuming Amazon's three skill tabs take SK6–15 (Bow), SK16–25 (Passive), SK26–35 (Javelin) in order — that #165 fixed for Sorc/Necro/Pal/Bar/Dru/Sin. PD2/D2's engine IDs interleave across the tabs, so opting into \"show staffmods\" for an Amazon was emitting rules that matched on one skill (engine ID) but labeled items with the name of a completely different skill.

## Background

[PR #165](https://github.com/Maaaaaarrk/FilterForge/pull/165) explicitly left Amazon as-is, citing ambiguity because the upstream HiimFilter staffmod file doesn't emit individual Amazon `SK###` rules. But internally FilterForge already has the canonical Amazon mapping in two places that agree:

- `SKILL_DATA[amazon]` at [js/editor.js:327](https://github.com/Maaaaaarrk/FilterForge/blob/main/js/editor.js#L327) — used by the Builder UI for skill conditions
- `SKILL_TAB_MAP` at [js/editor.js:341](https://github.com/Maaaaaarrk/FilterForge/blob/main/js/editor.js#L341) — used to translate SK# → tab index for MULTI codes

Both use the canonical PD2 engine IDs, and the [PD2 wiki Item Filtering page](https://wiki.projectdiablo2.com/wiki/Item_Filtering) confirms the same mapping (SK6 = Magic Arrow, SK8 = Inner Sight, SK11 = Cold Arrow, etc.). `aznSkills` was the outlier.

## Examples of what was wrong

| SK# | aznSkills said | Engine actually is |
|-----|----------------|---------------------|
| SK8 | ColdArw | Inner Sight |
| SK9 | MultShot | Critical Strike |
| SK10 | ExplArw | Jab |
| SK11 | IceArw | Cold Arrow |
| SK12 | GuidArw | Multiple Shot |
| SK13 | Strafe | Dodge |
| SK14 | Immolation | Power Strike |
| SK24 | Valkyrie | Charged Strike |
| SK29 | Impale | Evade (and Impale isn't a vanilla Amazon skill at all) |
| SK31 | ChrgStrk | Freezing Arrow (which was missing entirely) |

So a generated rule like `ItemDisplay[!UNI !SET !RW SK24=3]: %ORANGE%+3 Valkyrie %NAME%...` would fire on items with +3 Charged Strike, mislabeled as Valkyrie. Wrong matches, wrong labels.

## What this PR does

Rebuilds `aznSkills` from `SKILL_DATA[amazon]` (the canonical mapping), covering all 30 Amazon skills SK6–SK35 contiguously. Adds the missing Freezing Arrow (SK31) and Jav/Spear Mastery (SK19); removes the bogus Impale entry.

The `top` flag (third tuple element — controls whether the skill shows at all FILTLVL or only at low FILTLVL) preserves the previous semantic intent: popular endgame skills players chase on staffmod gear are `top=1` (Ice Arrow, Guided Arrow, Charged Strike, Plague Javelin, Strafe, Immolation, Freezing Arrow, Valkyrie, Pierce, Lightning Strike, Lightning Fury). Basic/utility skills are `top=0`.

## Test plan

- [ ] Open the wizard, select Amazon as the playing class, enable "show staffmods", generate
- [ ] Verify the generated `// --- Amazon Staffmods ---` section uses the correct `SK#` → name pairings (e.g. `SK22=3` labels as `+3 GuidArw`, `SK31=3` labels as `+3 FrzArw`)
- [ ] Spot-check that a previously broken pairing — `SK24=3` — now labels as `+3 ChrgStrk` (was: `+3 Valkyrie`)
- [ ] Confirm Sorc/Necro/Pal/Bar/Dru/Sin staffmod output is unchanged (only `aznSkills` was edited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)