### PR TITLE
sync: update Phyx10n filter sizes to upstream

### DIFF
--- a/data/author-filters.json
+++ b/data/author-filters.json
@@ -140,10 +140,10 @@
     "author": "Phyx10n",
     "repo": "Phyx10n/PD2-Filter",
     "files": [
-      {"name": "crafting+revealed.filter", "url": "https://raw.githubusercontent.com/Phyx10n/PD2-Filter/main/crafting+revealed.filter", "size": 175253},
-      {"name": "crafting.filter", "url": "https://raw.githubusercontent.com/Phyx10n/PD2-Filter/main/crafting.filter", "size": 175254},
-      {"name": "main.filter", "url": "https://raw.githubusercontent.com/Phyx10n/PD2-Filter/main/main.filter", "size": 175255},
-      {"name": "revealed.filter", "url": "https://raw.githubusercontent.com/Phyx10n/PD2-Filter/main/revealed.filter", "size": 175254}
+      {"name": "crafting+revealed.filter", "url": "https://raw.githubusercontent.com/Phyx10n/PD2-Filter/main/crafting+revealed.filter", "size": 162987},
+      {"name": "crafting.filter", "url": "https://raw.githubusercontent.com/Phyx10n/PD2-Filter/main/crafting.filter", "size": 162988},
+      {"name": "main.filter", "url": "https://raw.githubusercontent.com/Phyx10n/PD2-Filter/main/main.filter", "size": 162989},
+      {"name": "revealed.filter", "url": "https://raw.githubusercontent.com/Phyx10n/PD2-Filter/main/revealed.filter", "size": 162988}
     ]
   }
 ]


### PR DESCRIPTION
## Summary

All four files in Phyx10n/PD2-Filter shrank by ~12.3 KB (-7%) since the last catalog sync. The file size is displayed in the FilterForge UI next to each filter, and the rounded value changed from 175 KB to 163 KB, so this is a user-visible drift.

| File | Local | Upstream | Delta |
|------|-------|----------|-------|
| crafting+revealed.filter | 175253 | 162987 | -12266 |
| crafting.filter | 175254 | 162988 | -12266 |
| main.filter | 175255 | 162989 | -12266 |
| revealed.filter | 175254 | 162988 | -12266 |

## Other authors swept

Checked all 13 author repos listed in `data/author-filters.json`. Results:

- **12 authors in sync** (exact byte match or sub-0.05% drift that rounds to the same KB)
- **Phyx10n** — the only meaningful drift (-7%, >12 KB per file)

Minor cosmetic drift that was NOT synced in this PR:
- Kassahi: uniform +138 bytes across 8 files (~0.015%)
- HiimFilter: ~60-100 bytes uniform across 18 files (~0.03%)

Both round to the same displayed KB value in the UI, so they're not worth the catalog churn. A separate sync can absorb them later if we want byte-exact tracking.

## Test plan

- [ ] Open the app, go to the \"community filters\" picker, verify Phyx10n's four filters show as 159 KB (162987 / 1024 = 159.2 rounded) instead of 171 KB
- [ ] Click through one of the Phyx10n filters and confirm it loads successfully (no broken URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)