### PR TITLE
Fix #170: Append %CONTINUE% to paired rune display rules

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -3236,25 +3236,26 @@
 
       // Tier 1: High Runes (Lo #28 through Zod #33)
       lines.push('// --- High Runes (Lo - Zod) ---');
-      lines.push('ItemDisplay[RUNE~28-33]: ' + colorHR + decoHR_L + '%RUNENAME% Rune' + decoHR_R + ' (#%RUNENUM%)' + hrNotify);
+      lines.push('ItemDisplay[RUNE~28-33]: ' + colorHR + decoHR_L + '%RUNENAME% Rune' + decoHR_R + ' (#%RUNENUM%)' + hrNotify + '%CONTINUE%');
 
       // Tier 2: Mid-high Runes (Ist #24 through Ohm #27)
       lines.push('// --- Mid-High Runes (Ist - Ohm) ---');
-      lines.push('ItemDisplay[RUNE>23 RUNE<28]: ' + colorMidRune + decoMid_L + '%RUNENAME% Rune' + decoMid_R + ' (#%RUNENUM%)' + midNotify);
+      lines.push('ItemDisplay[RUNE>23 RUNE<28]: ' + colorMidRune + decoMid_L + '%RUNENAME% Rune' + decoMid_R + ' (#%RUNENUM%)' + midNotify + '%CONTINUE%');
 
       // Tier 3: Mid Runes (Lem #20 through Mal #23)
       lines.push('// --- Mid Runes (Lem - Mal) ---');
-      lines.push('ItemDisplay[RUNE>19 RUNE<24]: ' + colorMidRune + decoLow_L + '%RUNENAME% Rune' + decoLow_R + ' (#%RUNENUM%)' + midRuneNotify);
+      lines.push('ItemDisplay[RUNE>19 RUNE<24]: ' + colorMidRune + decoLow_L + '%RUNENAME% Rune' + decoLow_R + ' (#%RUNENUM%)' + midRuneNotify + '%CONTINUE%');
 
       // Tier 4: Low Runes (El #1 through Fal #19)
       lines.push('// --- Low Runes (El - Fal) ---');
-      lines.push('ItemDisplay[RUNE>14 RUNE<20]: ' + colorLowRune + '%RUNENAME% Rune (#%RUNENUM%)' + lowRuneDot);
-      lines.push('ItemDisplay[RUNE>10 RUNE<15]: %ORANGE%%RUNENAME% (#%RUNENUM%)');
-      lines.push('ItemDisplay[RUNE>0 RUNE<11]: %ORANGE%%RUNENAME% (#%RUNENUM%)');
+      lines.push('ItemDisplay[RUNE>14 RUNE<20]: ' + colorLowRune + '%RUNENAME% Rune (#%RUNENUM%)' + lowRuneDot + '%CONTINUE%');
+      lines.push('ItemDisplay[RUNE>10 RUNE<15]: %ORANGE%%RUNENAME% (#%RUNENUM%)%CONTINUE%');
+      lines.push('ItemDisplay[RUNE>0 RUNE<11]: %ORANGE%%RUNENAME% (#%RUNENUM%)%CONTINUE%');
       lines.push('');
 
       // Rune stacking display (from Wolfie/HiimFilter)
-      // Must come after all tier rules so CONTINUE doesn't suppress tier decoration
+      // Tier rules above use %CONTINUE% so this rule fires for stacks,
+      // appending the quantity while preserving the tier decoration.
       lines.push('// --- Rune Stack Display ---');
       lines.push('ItemDisplay[RUNE>0 QTY>1]: %NAME% %TAN%x%QTY%{%NAME%}%CONTINUE%');
       lines.push('');


### PR DESCRIPTION
## Summary
Fixes #170. The wizard's rune section in `js/editor.js` emits a series of tier rules (High / Mid-High / Mid / Low) followed by a single stack-display rule `ItemDisplay[RUNE>0 QTY>1]: %NAME% %TAN%x%QTY%{%NAME%}%CONTINUE%`. Because PD2 filters stop at the first matching `ItemDisplay` rule unless it ends with `%CONTINUE%`, the stack-display rule never fired for stacked runes — the tier rule consumed the match and suppressed the quantity display.

The comment above the stack rule already acknowledged the intended chain semantics ("Must come after all tier rules so CONTINUE doesn't suppress tier decoration"), but the tier rules themselves were missing the `%CONTINUE%` token.

### Before
```
ItemDisplay[RUNE>0 RUNE<11]: %ORANGE%%RUNENAME% (#%RUNENUM%)
ItemDisplay[RUNE>0 QTY>1]: %NAME% %TAN%x%QTY%{%NAME%}%CONTINUE%
```
Stacked El runes only show the tier line — quantity never appears.

### After
```
ItemDisplay[RUNE>0 RUNE<11]: %ORANGE%%RUNENAME% (#%RUNENUM%)%CONTINUE%
ItemDisplay[RUNE>0 QTY>1]: %NAME% %TAN%x%QTY%{%NAME%}%CONTINUE%
```
Tier rule stores its decorated output into `%NAME%`, stack rule appends `x%QTY%`.

Fix applied to all six tier rules (covering High runes / "hrs", Mid-High, Mid, Low x3), so the "same for hrs etc." cases mentioned in the issue are all handled by this single change.

## Test plan
- [ ] Generate a filter via the wizard with runes enabled.
- [ ] Verify each of the six rune tier `ItemDisplay` lines ends with `%CONTINUE%`.
- [ ] In-game: stack 2+ El runes — name should include `x2`; 2+ Zod runes — name should include `x2` and keep the HR decoration.

Closes #170

Generated with Claude Code