### PR TITLE
Fix #175: Show Kassahi 'philanthropy777' filter labels instead of 'Luxe'

### DIFF
--- a/data/author-filters.json
+++ b/data/author-filters.json
@@ -22,15 +22,16 @@
     "name": "Kassahi's PD2 Filter",
     "author": "Kassahi",
     "repo": "KassahiPD2/Kassahi",
+    "definitionsUrl": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/filter_definitions.json",
     "files": [
-      {"name": "Meme-Hyper.filter", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Meme-Hyper.filter", "size": 916495},
-      {"name": "Meme.filter", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Meme.filter", "size": 916052},
-      {"name": "Mystery-Hyper.filter", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Mystery-Hyper.filter", "size": 916362},
-      {"name": "Mystery-Luxe.filter", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Mystery-Luxe.filter", "size": 919171},
-      {"name": "Mystery.filter", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Mystery.filter", "size": 915909},
-      {"name": "Regular-Hyper.filter", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Regular-Hyper.filter", "size": 915063},
-      {"name": "Regular-Luxe.filter", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Regular-Luxe.filter", "size": 917819},
-      {"name": "Regular.filter", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Regular.filter", "size": 914620}
+      {"name": "Regular.filter", "displayName": "Regular-Standard", "description": "All-in-one balanced filter. The standard recommendation for most players.", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Regular.filter", "size": 914620},
+      {"name": "Regular-Hyper.filter", "displayName": "Regular-Hyper", "description": "Standard filter with a Hyper visual theme.", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Regular-Hyper.filter", "size": 915063},
+      {"name": "Regular-Luxe.filter", "displayName": "Regular-philanthropy777", "description": "Standard filter with a philanthropy777 visual theme.", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Regular-Luxe.filter", "size": 917819},
+      {"name": "Meme.filter", "displayName": "Meme-Standard", "description": "Standard filter with meme item names for a humorous experience.", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Meme.filter", "size": 916052},
+      {"name": "Meme-Hyper.filter", "displayName": "Meme-Hyper", "description": "Meme filter with a Hyper visual theme.", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Meme-Hyper.filter", "size": 916495},
+      {"name": "Mystery.filter", "displayName": "Mystery-Standard", "description": "Filter where high-value items are renamed to hide their identity.", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Mystery.filter", "size": 915909},
+      {"name": "Mystery-Hyper.filter", "displayName": "Mystery-Hyper", "description": "Mystery filter with a Hyper visual theme.", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Mystery-Hyper.filter", "size": 916362},
+      {"name": "Mystery-Luxe.filter", "displayName": "Mystery-philanthropy777", "description": "Mystery filter with a philanthropy777 visual theme.", "url": "https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Mystery-Luxe.filter", "size": 919171}
     ]
   },
   {

--- a/js/editor.js
+++ b/js/editor.js
@@ -5786,15 +5786,17 @@
       {name:"futureal.filter",url:"https://raw.githubusercontent.com/Kryszard-POD/Kryszard-s-PD2-Loot-Filter/main/futureal.filter",size:724417},
       {name:"item.filter",url:"https://raw.githubusercontent.com/Kryszard-POD/Kryszard-s-PD2-Loot-Filter/main/item.filter",size:720579}
     ]},
-    {name:"Kassahi's PD2 Filter",author:"Kassahi",repo:"KassahiPD2/Kassahi",files:[
-      {name:"Meme-Hyper.filter",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Meme-Hyper.filter",size:916495},
-      {name:"Meme.filter",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Meme.filter",size:916052},
-      {name:"Mystery-Hyper.filter",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Mystery-Hyper.filter",size:916362},
-      {name:"Mystery-Luxe.filter",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Mystery-Luxe.filter",size:919171},
-      {name:"Mystery.filter",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Mystery.filter",size:915909},
-      {name:"Regular-Hyper.filter",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Regular-Hyper.filter",size:915063},
-      {name:"Regular-Luxe.filter",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Regular-Luxe.filter",size:917819},
-      {name:"Regular.filter",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Regular.filter",size:914620}
+    {name:"Kassahi's PD2 Filter",author:"Kassahi",repo:"KassahiPD2/Kassahi",
+      definitionsUrl:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/filter_definitions.json",
+      files:[
+      {name:"Regular.filter",displayName:"Regular-Standard",description:"All-in-one balanced filter. The standard recommendation for most players.",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Regular.filter",size:914620},
+      {name:"Regular-Hyper.filter",displayName:"Regular-Hyper",description:"Standard filter with a Hyper visual theme.",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Regular-Hyper.filter",size:915063},
+      {name:"Regular-Luxe.filter",displayName:"Regular-philanthropy777",description:"Standard filter with a philanthropy777 visual theme.",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Regular-Luxe.filter",size:917819},
+      {name:"Meme.filter",displayName:"Meme-Standard",description:"Standard filter with meme item names for a humorous experience.",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Meme.filter",size:916052},
+      {name:"Meme-Hyper.filter",displayName:"Meme-Hyper",description:"Meme filter with a Hyper visual theme.",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Meme-Hyper.filter",size:916495},
+      {name:"Mystery.filter",displayName:"Mystery-Standard",description:"Filter where high-value items are renamed to hide their identity.",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Mystery.filter",size:915909},
+      {name:"Mystery-Hyper.filter",displayName:"Mystery-Hyper",description:"Mystery filter with a Hyper visual theme.",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Mystery-Hyper.filter",size:916362},
+      {name:"Mystery-Luxe.filter",displayName:"Mystery-philanthropy777",description:"Mystery filter with a philanthropy777 visual theme.",url:"https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/Mystery-Luxe.filter",size:919171}
     ]},
     {name:"Erazure's PD2 Loot Filter",author:"Erazure",repo:"FiltersBy-Erazure/PD2-Loot-Filter",files:[
       {name:"Erazure-BIG-GG-PoE.filter",displayName:"BIG GG \u2014 PoE Sounds",description:"Strict filter with PoE-style drop sounds.",url:"https://raw.githubusercontent.com/FiltersBy-Erazure/PD2-Loot-Filter/main/Erazure-BIG-GG-PoE.filter",size:775381},


### PR DESCRIPTION
## Summary
- Closes #175. @philanthropy777 reported that the Kassahi filter still labels his variant as "Luxe" in the FilterForge editor.
- Upstream Kassahi (`KassahiPD2/Kassahi`) already renamed the display names to **Regular-philanthropy777** and **Mystery-philanthropy777** in `filter_definitions.json` and `builderfilter/filters.json`. The underlying `.filter` filenames are still `Regular-Luxe.filter` / `Mystery-Luxe.filter`, but those are URLs, not user-facing labels.
- FilterForge's Kassahi entry was rendering raw filenames because (unlike the HiimFilter entry) it had no `definitionsUrl` and no static `displayName` / `description` fallbacks.

## Changes
- `data/author-filters.json` and `js/editor.js`: added `definitionsUrl` for the Kassahi entry pointing at `https://raw.githubusercontent.com/KassahiPD2/Kassahi/main/filter_definitions.json` so the editor fetches live display names (matches the HiimFilter pattern at `editor.js:5805-5806` / `selectAuthor` at `editor.js:5941`).
- Added per-file `displayName` / `description` to all Kassahi files as the static fallback used when the live fetch fails. The two Luxe files now display as `Regular-philanthropy777` / `Mystery-philanthropy777` even offline.
- Reordered the file list to match the upstream `filter_definitions.json` ordering (Regular variants, Meme variants, Mystery variants).

## Test plan
- [ ] Open the editor, select Kassahi: confirm the file list shows display names like **Regular-philanthropy777** and **Mystery-philanthropy777** instead of `Regular-Luxe.filter` / `Mystery-Luxe.filter`.
- [ ] Block network access to `raw.githubusercontent.com/KassahiPD2/Kassahi/main/filter_definitions.json` and reload: confirm the static fallback still shows the new display names.
- [ ] Confirm the actual `.filter` URL still downloads correctly (filenames unchanged).