### PR TITLE
Fix #177: View All filter-level dropdown clamped to 0/1 on community load

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -5623,14 +5623,23 @@
   var ALL_ITEMS_CACHE = null;
 
   function parseFilterLevelNames(text) {
+    // Supports both syntaxes used by community filters:
+    //   ItemDisplayFilterName[]: Name        (sequential — Wolfie, Hiim, eqN, Sven, Roofoo, Dauracul, ...)
+    //   ItemDisplayFilterName[3]: Name       (explicit index — Kassahi)
     var names = {};
     var lines = text.split('\n');
-    var level = 1;
+    var seqLevel = 1;
     for (var i = 0; i < lines.length; i++) {
-      var m = lines[i].match(/^ItemDisplayFilterName\s*\[\s*\]\s*:\s*(.+)/);
+      var m = lines[i].match(/^ItemDisplayFilterName\s*\[\s*(\d*)\s*\]\s*:\s*(.+)/);
       if (m) {
-        names[level] = m[1].trim();
-        level++;
+        // Strip trailing "// comment" some filters use to label the level number
+        var raw = m[2].replace(/\s*\/\/.*$/, '').trim();
+        if (m[1]) {
+          names[parseInt(m[1], 10)] = raw;
+        } else {
+          names[seqLevel] = raw;
+          seqLevel++;
+        }
       }
     }
     return names;
@@ -5640,7 +5649,11 @@
     var names = parseFilterLevelNames(text);
     var currentVal = selectEl.value || '1';
     selectEl.innerHTML = '<option value="0">0 — Off</option>';
-    var maxLevel = Math.max(Object.keys(names).length, 1);
+    // Use highest defined level (handles both sequential [] and indexed [N] syntax,
+    // including filters like Kassahi that go up to [12]).
+    var levelKeys = Object.keys(names).map(function (k) { return parseInt(k, 10); });
+    var maxLevel = levelKeys.length ? Math.max.apply(null, levelKeys) : 1;
+    if (maxLevel < 1) maxLevel = 1;
     for (var lvl = 1; lvl <= maxLevel; lvl++) {
       var label = names[lvl] ? lvl + ' — ' + names[lvl] : String(lvl);
       selectEl.innerHTML += '<option value="' + lvl + '"' + (String(lvl) === currentVal ? ' selected' : '') + '>' + label + '</option>';


### PR DESCRIPTION
## Summary

The "view all" filter-level dropdown only showed levels `0` and `1` after loading certain community filters (most visibly Kassahi).

Root cause: `parseFilterLevelNames()` in `js/editor.js` matched only the empty-bracket sequential form `ItemDisplayFilterName[]:` and silently skipped the explicit-index form `ItemDisplayFilterName[N]:`. Kassahi's filters use the indexed form (up to `[12]`), so the parser found zero levels and `populateFilterLevelDropdown` fell back to its `Math.max(count, 1) = 1` floor — a dropdown with just `0 — Off` and `1`.

## Changes

- Regex now accepts both `ItemDisplayFilterName[]:` and `ItemDisplayFilterName[N]:`.
- `maxLevel` is taken from the highest defined index instead of the key count, so gapped indices still produce a complete dropdown.
- Trailing `// comment` in level names is stripped (e.g. Sven's `Leveling Filter (suggested 1-60)//1` no longer leaks the comment into the option label).

## Test plan

- [ ] Load Kassahi's `Mystery.filter` via Community Author Import - All Items dropdown should show levels 1 through 12.
- [ ] Load Wolfie's `combined.filter` - dropdown should still show 5 named levels (Detailed, Revealed, Vanilla, Wolfie, Runewords & Recipes).
- [ ] Load Sven's `loot.filter` - 4 levels, names without trailing `//N`.
- [ ] Load Hiim/eqN/Roofoo/Dauracul filters - all sequential `[]` cases still work.
- [ ] Builder-generated filter (no community import) - 4 default levels still appear.

Closes #177

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>