### PR TITLE
fix: prevent duplicate [Eth] tag on socketed ethereal items

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -3013,11 +3013,11 @@
         if (wantEthTag && wantSockets) {
           lines.push('// Magic+ items: Eth tag and socket count');
           lines.push('ItemDisplay[(MAG OR UNI OR SET OR RARE OR CRAFT) !RW ETH SOCK>0]: %NAME% %GRAY%[Eth] [%SOCKETS%]%CONTINUE%');
-          lines.push('ItemDisplay[(MAG OR UNI OR SET OR RARE OR CRAFT) ETH]: %NAME% %GRAY%[Eth]%CONTINUE%');
+          lines.push('ItemDisplay[(MAG OR UNI OR SET OR RARE OR CRAFT) ETH !SOCK>0]: %NAME% %GRAY%[Eth]%CONTINUE%');
           lines.push('ItemDisplay[(MAG OR UNI OR SET OR RARE OR CRAFT) !RW !ETH SOCK>0]: %NAME% [%SOCKETS%]%CONTINUE%');
           lines.push('// Normal items: Eth tag and socket count');
           lines.push('ItemDisplay[NMAG !RW ETH SOCK>0]: %GRAY%%NAME% [Eth] [%SOCKETS%]%CONTINUE%');
-          lines.push('ItemDisplay[NMAG ETH]: %GRAY%%NAME% [Eth]%CONTINUE%');
+          lines.push('ItemDisplay[NMAG ETH !SOCK>0]: %GRAY%%NAME% [Eth]%CONTINUE%');
           lines.push('ItemDisplay[NMAG !RW !ETH SOCK>0]: %GRAY%%NAME% [%SOCKETS%]%CONTINUE%');
         } else if (wantEthTag) {
           lines.push('ItemDisplay[(MAG OR UNI OR SET OR RARE OR CRAFT) ETH]: %NAME% %GRAY%[Eth]%CONTINUE%');


### PR DESCRIPTION
## Summary

- When both **eth tag** and **socket count** extras are enabled, the `ETH SOCK>0` rules use `%CONTINUE%`, which caused the ETH-only fallthrough rules to also fire for the same item — appending `[Eth]` twice (e.g. `[19%] Superior Brandistock [Eth] [2] [Eth]`)
- Added `!SOCK>0` to the ETH-only fallthrough rules for both NMAG and Magic+ items, making them mutually exclusive with the `ETH SOCK>0` rules

## Root cause

In `buildFilter()` ([js/editor.js:3013](js/editor.js#L3013)), when `wantEthTag && wantSockets`, the generated rules were:

```
ItemDisplay[NMAG !RW ETH SOCK>0]: %GRAY%%NAME% [Eth] [%SOCKETS%]%CONTINUE%
ItemDisplay[NMAG ETH]: %GRAY%%NAME% [Eth]%CONTINUE%   ← also matched socketed eth items via %CONTINUE%
```

A socketed eth item hits the first rule, gets `[Eth] [2]`, then `%CONTINUE%` falls through to the second rule which also matches (no socket restriction), appending `[Eth]` again.

## Fix

Added `!SOCK>0` to the ETH-only rules so they only match **unsocketed** eth items:

```
ItemDisplay[NMAG ETH !SOCK>0]: %GRAY%%NAME% [Eth]%CONTINUE%
ItemDisplay[(MAG OR UNI OR SET OR RARE OR CRAFT) ETH !SOCK>0]: %NAME% %GRAY%[Eth]%CONTINUE%
```

## Test plan

- [ ] Generate a filter with both **Eth tag** and **Socket count** extras enabled
- [ ] Verify a Superior Ethereal socketed item shows `[19%] Superior Brandistock [Eth] [2]` (not `[Eth] [2] [Eth]`)
- [ ] Verify an Ethereal item with no sockets still shows `[Eth]` correctly
- [ ] Verify a socketed non-eth item still shows `[2]` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)