### PR TITLE
Fix #186: keep content tokens in the All-Items hidden check

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1926,6 +1926,25 @@
     return rules;
   }
 
+  // Returns true if `str` would render to an empty/invisible name in-game.
+  // Strips only formatting/notification tokens (colors, borders, sounds, %CONTINUE%, etc.)
+  // — content-producing tokens like %NAME%, %BASENAME%, %ILVL%, %SOCK% are preserved
+  // because they expand to visible text. Without this distinction, an output like
+  // "%WHITE%%BASENAME%" would be wrongly classified as hidden.
+  function isHiddenName(str) {
+    if (!str) return true;
+    var s = str
+      .replace(/%(?:WHITE|RED|GREEN|DARK_GREEN|BLUE|GOLD|YELLOW|ORANGE|PURPLE|GRAY|BLACK|TAN|CORAL|SAGE|TEAL|LIGHT_GRAY)%/g, '')
+      .replace(/%(?:BORDER|MAP|DOT|PX)(?:-[0-9A-Fa-f]{1,2})?%/g, '')
+      .replace(/%SOUNDID-\d+%/g, '')
+      .replace(/%SOUND_\d+%/g, '')
+      .replace(/%NOTIFY[^%]*%/g, '')
+      .replace(/%CONTINUE%/g, '')
+      .replace(/%TIER-\d+%/g, '')
+      .replace(/%(?:CL|CS|NL)%/g, '');
+    return !s.trim();
+  }
+
   function matchItem(item, rules) {
     // PD2 %CONTINUE% semantics (from wiki):
     // - %CONTINUE% stores the current rule's output into %NAME% and continues checking.
@@ -1981,7 +2000,7 @@
         return {
           matched: true,
           rule: rule,
-          hidden: finalOutput === '' || !namePart.replace(/%[A-Z_0-9-]+%/g, '').trim(),
+          hidden: finalOutput === '' || isHiddenName(namePart),
           output: finalOutput,
           continued: anyMatched,
           allRules: allMatchedRules
@@ -1993,8 +2012,7 @@
     if (anyMatched) {
       var finalOut = storedName;
       if (storedDesc) finalOut = storedName + '{' + storedDesc + '}';
-      var nameVisible = storedName.replace(/%[A-Z_0-9-]+%/g, '').trim();
-      return { matched: true, rule: lastRule, hidden: !nameVisible, output: finalOut, continued: true, allRules: allMatchedRules };
+      return { matched: true, rule: lastRule, hidden: isHiddenName(storedName), output: finalOut, continued: true, allRules: allMatchedRules };
     }
     return { matched: false, hidden: false, output: '', rule: null, allRules: [] };
   }


### PR DESCRIPTION
Closes #186

## Summary
The All-Items preview marked a NMAG Mage Plate as "hidden" under the Hiim — Standard filter at FILTLVL=6, even though the matching rule (`ItemDisplay[xtp !INF !ETH NMAG !RW !SOCK=1 (EDEF>14 OR FILTLVL<7)]: %NAME%{%NAME%}`) actually shows it in-game.

Root cause: the previous hidden check stripped every `%TOKEN%` before testing for visible text:

```js
hidden: !namePart.replace(/%[A-Z_0-9-]+%/g, '').trim()
```

After the CONTINUE chain (lines 871 → 3795 → 4889) the namePart resolves to `%WHITE%%BASENAME%`. Stripping both tokens leaves an empty string, so the rule was wrongly flagged hidden. But `%BASENAME%` renders to actual base-item text, so the item is visible in-game.

Fix: introduce `isHiddenName()` which only strips formatting/notification tokens (colors, borders, dots, sounds, `%CONTINUE%`, `%TIER-N%`, `%CL%`/`%CS%`/`%NL%`). Content tokens like `%NAME%`, `%BASENAME%`, `%ILVL%`, `%SOCK%`, `%QTY%`, etc. are preserved, so any rule that includes them is correctly classified as shown.

Empty-output hide rules (e.g. `ItemDisplay[ear]:` or `GOLD<7500 ...]:`) still register as hidden because `isHiddenName('')` returns true.

## Test plan
- [ ] Open editor with Hiim — Standard, switch to All Items tab, set FILTLVL=6, verify NMAG Mage Plate shows as "show"
- [ ] FILTLVL=9 + Hiim — Standard: NMAG Mage Plate should still appear "hide" (rule 5624 namePart is `%NOTIFY-DEAD%` which strips to empty)
- [ ] Ear and gold-below-threshold rules still preview as hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)