### PR TITLE
Add in-editor find with next/prev buttons

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -484,12 +484,87 @@
 
 .editor-meta {
   display: flex;
+  align-items: center;
   gap: 1rem;
   padding: 0.4rem 0.75rem;
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
   font-size: 0.78rem;
   color: var(--text-secondary);
+}
+
+.editor-meta-btn {
+  margin-left: auto;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.75rem;
+}
+
+.editor-find {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.6rem;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+}
+
+.editor-find[hidden] { display: none; }
+
+.editor-find-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0.3rem 0.5rem;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  outline: none;
+}
+
+.editor-find-input:focus {
+  border-color: var(--accent-primary);
+}
+
+.editor-find-input.no-match {
+  border-color: #ff4040;
+}
+
+.editor-find-count {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  min-width: 3.5rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.editor-find-toggle {
+  padding: 0.2rem 0.4rem;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  font-family: var(--font-mono);
+}
+
+.editor-find-toggle[aria-pressed="true"] {
+  background: var(--accent-primary);
+  color: var(--bg-primary);
+  border-color: var(--accent-primary);
+}
+
+.editor-find-btn {
+  padding: 0.2rem 0.4rem;
+  font-size: 0.7rem;
+}
+
+.editor-find-close {
+  padding: 0 0.4rem;
+  font-size: 1.1rem;
 }
 
 /* Code editor */

--- a/editor.html
+++ b/editor.html
@@ -827,6 +827,15 @@
               <span class="line-count" id="line-count">Lines: 0</span>
               <span class="char-count" id="char-count">Chars: 0</span>
               <span class="rule-count" id="rule-count">Rules: 0</span>
+              <button class="btn-small editor-meta-btn" id="btn-find" title="Find in editor (Ctrl+F)">Find</button>
+            </div>
+            <div class="editor-find" id="editor-find" hidden>
+              <input type="text" class="editor-find-input" id="editor-find-input" placeholder="Find" aria-label="Find in editor" autocomplete="off" spellcheck="false">
+              <span class="editor-find-count" id="editor-find-count">0 / 0</span>
+              <button class="editor-find-toggle" id="editor-find-case" title="Match case" aria-pressed="false">Aa</button>
+              <button class="btn-icon editor-find-btn" id="editor-find-prev" title="Previous match (Shift+Enter)" aria-label="Previous match">&#9650;</button>
+              <button class="btn-icon editor-find-btn" id="editor-find-next" title="Next match (Enter)" aria-label="Next match">&#9660;</button>
+              <button class="btn-icon editor-find-close" id="editor-find-close" title="Close (Esc)" aria-label="Close find">&times;</button>
             </div>
             <div class="code-editor-wrap">
               <div class="line-numbers" id="line-numbers"></div>

--- a/js/editor.js
+++ b/js/editor.js
@@ -6226,6 +6226,185 @@
   }
 
   // ==========================================
+  // In-editor Find (Ctrl+F, next/prev)
+  // ==========================================
+  function initEditorFind() {
+    var bar = document.getElementById('editor-find');
+    var input = document.getElementById('editor-find-input');
+    var countEl = document.getElementById('editor-find-count');
+    var caseBtn = document.getElementById('editor-find-case');
+    var prevBtn = document.getElementById('editor-find-prev');
+    var nextBtn = document.getElementById('editor-find-next');
+    var closeBtn = document.getElementById('editor-find-close');
+    var openBtn = document.getElementById('btn-find');
+    if (!bar || !input || !codeEditor) return;
+
+    var caseSensitive = false;
+    var matches = [];
+    var currentIdx = -1;
+
+    function escapeRegex(str) {
+      return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+
+    function computeMatches() {
+      matches = [];
+      var term = input.value;
+      if (!term) {
+        currentIdx = -1;
+        updateCount();
+        return;
+      }
+      var flags = caseSensitive ? 'g' : 'gi';
+      var re;
+      try { re = new RegExp(escapeRegex(term), flags); } catch (e) { return; }
+      var text = codeEditor.value;
+      var m;
+      while ((m = re.exec(text)) !== null) {
+        matches.push({ start: m.index, end: m.index + m[0].length });
+        if (m[0].length === 0) re.lastIndex++;
+      }
+      updateCount();
+    }
+
+    function updateCount() {
+      if (!input.value) {
+        countEl.textContent = '0 / 0';
+        input.classList.remove('no-match');
+      } else if (matches.length === 0) {
+        countEl.textContent = '0 / 0';
+        input.classList.add('no-match');
+      } else {
+        countEl.textContent = (currentIdx + 1) + ' / ' + matches.length;
+        input.classList.remove('no-match');
+      }
+    }
+
+    function scrollMatchIntoView(match) {
+      var before = codeEditor.value.substring(0, match.start);
+      var lineNum = 0;
+      for (var i = 0; i < before.length; i++) {
+        if (before.charCodeAt(i) === 10) lineNum++;
+      }
+      var lineHeight = parseFloat(getComputedStyle(codeEditor).lineHeight) || 18;
+      var wrap = document.querySelector('.code-editor-wrap');
+      if (!wrap) return;
+      var targetY = lineNum * lineHeight;
+      var viewTop = wrap.scrollTop;
+      var viewBottom = viewTop + wrap.clientHeight;
+      if (targetY < viewTop || targetY + lineHeight > viewBottom) {
+        wrap.scrollTop = Math.max(0, targetY - wrap.clientHeight / 2);
+      }
+    }
+
+    function selectMatch(idx) {
+      if (matches.length === 0) { updateCount(); return; }
+      if (idx < 0) idx = matches.length - 1;
+      if (idx >= matches.length) idx = 0;
+      currentIdx = idx;
+      var m = matches[currentIdx];
+      codeEditor.focus();
+      codeEditor.setSelectionRange(m.start, m.end);
+      scrollMatchIntoView(m);
+      updateCount();
+    }
+
+    function findNext() {
+      if (matches.length === 0) computeMatches();
+      if (matches.length === 0) { updateCount(); return; }
+      selectMatch(currentIdx + 1);
+    }
+
+    function findPrev() {
+      if (matches.length === 0) computeMatches();
+      if (matches.length === 0) { updateCount(); return; }
+      selectMatch(currentIdx - 1);
+    }
+
+    function openFind() {
+      bar.hidden = false;
+      var caret = codeEditor.selectionStart;
+      var sel = codeEditor.value.substring(codeEditor.selectionStart, codeEditor.selectionEnd);
+      if (sel && sel.length < 200 && sel.indexOf('\n') === -1) {
+        input.value = sel;
+      }
+      computeMatches();
+      currentIdx = -1;
+      if (matches.length > 0 && input.value) {
+        var startIdx = 0;
+        for (var i = 0; i < matches.length; i++) {
+          if (matches[i].start >= caret) { startIdx = i; break; }
+          startIdx = 0;
+        }
+        selectMatch(startIdx);
+      }
+      input.focus();
+      input.select();
+    }
+
+    function closeFind() {
+      bar.hidden = true;
+      input.classList.remove('no-match');
+      codeEditor.focus();
+    }
+
+    input.addEventListener('input', function () {
+      computeMatches();
+      currentIdx = -1;
+      if (matches.length > 0) selectMatch(0);
+    });
+
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (e.shiftKey) findPrev(); else findNext();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        closeFind();
+      }
+    });
+
+    nextBtn.addEventListener('click', findNext);
+    prevBtn.addEventListener('click', findPrev);
+    closeBtn.addEventListener('click', closeFind);
+    if (openBtn) openBtn.addEventListener('click', function () {
+      if (bar.hidden) openFind(); else closeFind();
+    });
+
+    caseBtn.addEventListener('click', function () {
+      caseSensitive = !caseSensitive;
+      caseBtn.setAttribute('aria-pressed', caseSensitive ? 'true' : 'false');
+      computeMatches();
+      currentIdx = -1;
+      if (matches.length > 0) selectMatch(0);
+      input.focus();
+    });
+
+    document.addEventListener('keydown', function (e) {
+      var key = e.key;
+      if ((e.ctrlKey || e.metaKey) && (key === 'f' || key === 'F')) {
+        var pane = document.getElementById('pane-code');
+        if (!pane || pane.style.display === 'none') return;
+        var active = document.activeElement;
+        var inEditorArea = active === codeEditor || active === input || (pane.contains(active));
+        if (!inEditorArea) return;
+        e.preventDefault();
+        if (bar.hidden) openFind(); else { input.focus(); input.select(); }
+      } else if (key === 'Escape' && !bar.hidden) {
+        e.preventDefault();
+        closeFind();
+      }
+    });
+
+    codeEditor.addEventListener('input', function () {
+      if (!bar.hidden) {
+        computeMatches();
+        currentIdx = -1;
+      }
+    });
+  }
+
+  // ==========================================
   // Initialize everything
   // ==========================================
   function init() {
@@ -6252,6 +6431,7 @@
     initAuthorImport();
     initCommunityMode();
     initAllItems();
+    initEditorFind();
 
     // Auto-open author import if ?author= in URL
     var urlParams2 = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- Adds an in-editor find UI scoped to the filter editor content (the browser Ctrl+F covers the whole page and misses content inside the editor widget).
- Find input + Next / Prev buttons + match position indicator.
- Ctrl+F opens it when focus is in the editor; Esc closes; Enter advances.

Closes #188

## Test plan
- [ ] Open the editor, press Ctrl+F, type a term that exists multiple times (e.g. `ItemDisplay`).
- [ ] Next cycles forward through matches, scrolling each into view.
- [ ] Prev cycles backward.
- [ ] Position indicator (`n / total`) updates.
- [ ] Esc closes the find bar.
- [ ] Browser Ctrl+F does not also open while focus is in the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)