### PR TITLE
Add post-ID grading for jewels and charms

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -304,6 +304,14 @@
                   <strong>Weapon Base Speed</strong>
                   <span>Show base speed and range in weapon descriptions (e.g. "Base Speed: -10 || Range: +3") (excludes wands and orbs)</span>
                 </button>
+                <button class="wizard-opt" data-value="gradejewelcharm">
+                  <strong>Grade Jewels & Charms</strong>
+                  <span>Highlight identified jewels and small/large/grand charms with good rolls (life, mana, res, MF, FCR/IAS, +1 skill tab, etc.)</span>
+                </button>
+                <button class="wizard-opt" data-value="lowrollcharm">
+                  <strong>Tag low-roll charms</strong>
+                  <span>Show gray [bad] label on identified magic charms that rolled no meaningful affix</span>
+                </button>
               </div>
             </div>
 

--- a/js/editor.js
+++ b/js/editor.js
@@ -4781,10 +4781,9 @@
       if (c.extras.indexOf('lowrollcharm') !== -1) {
         lines.push('// --- Low-roll Charm Tag ---');
         var notTab = '!TABSK0 !TABSK1 !TABSK2 !TABSK8 !TABSK9 !TABSK10 !TABSK16 !TABSK17 !TABSK18 !TABSK24 !TABSK25 !TABSK26 !TABSK32 !TABSK33 !TABSK34 !TABSK40 !TABSK41 !TABSK42 !TABSK48 !TABSK49 !TABSK50';
-        var notClsk = '!CLSK0 !CLSK1 !CLSK2 !CLSK3 !CLSK4 !CLSK5 !CLSK6';
-        lines.push('ItemDisplay[cm1 MAG ID ' + notClsk + ' !RES !LIFE !MANA !STAT80 !FHR !EDAM ' + notTab + ']: %GRAY%[bad] %NAME%');
-        lines.push('ItemDisplay[cm2 MAG ID ' + notClsk + ' !RES !LIFE !MANA !STAT80 !FHR !EDAM ' + notTab + ']: %GRAY%[bad] %NAME%');
-        lines.push('ItemDisplay[cm3 MAG ID ' + notClsk + ' !RES !LIFE !MANA !STAT80 !FHR !EDAM ' + notTab + ']: %GRAY%[bad] %NAME%');
+        lines.push('ItemDisplay[cm1 MAG ID !RES !LIFE !MANA !STAT80 !FHR !EDAM ' + notTab + ']: %GRAY%[bad] %NAME%');
+        lines.push('ItemDisplay[cm2 MAG ID !RES !LIFE !MANA !STAT80 !FHR !EDAM ' + notTab + ']: %GRAY%[bad] %NAME%');
+        lines.push('ItemDisplay[cm3 MAG ID !RES !LIFE !MANA !STAT80 !FHR !EDAM ' + notTab + ']: %GRAY%[bad] %NAME%');
       }
       lines.push('');
 

--- a/js/editor.js
+++ b/js/editor.js
@@ -2921,6 +2921,7 @@
         circles: 'Circles', dots: 'Dots', crosses: 'Crosses', middot: 'Middle Dots',
         sockets: 'Socket Count', ilvl: 'Item Level', price: 'Vendor Price',
         crafting: 'Crafting Info', eth: 'Ethereal Tag', shortnames: 'Short Names', charmshort: 'Charm Short Names', uniquenames: 'Reveal Uniques', staffmods: 'Staffmods', wpnspeed: 'Weapon Speed',
+        gradejewelcharm: 'Grade Jewels & Charms', lowrollcharm: 'Tag low-roll charms',
         'all-rw': 'All Good Bases', 'eth-rw': 'Eth Bases Only', 'none-rw': 'None',
         hidegold: 'Hide Low Gold', hidekeys: 'Hide Keys',
         hidescrolls: 'Hide Scrolls', hidepots: 'Hide Small Potions',
@@ -4738,6 +4739,53 @@
       lines.push('ItemDisplay[WEAPON (MAG OR RARE OR CRAFT) ID EDAM>199]: %ORANGE%%EDAM%ED %NAME%%CONTINUE%{%NAME%}');
       // Chest DEF display
       lines.push('ItemDisplay[CHEST (MAG OR RARE OR CRAFT) ID DEF>400]: %TAN%%DEF%Def %NAME%%CONTINUE%{%NAME%}');
+
+      // Jewel & Charm grading (opt-in via extras toggles)
+      if (c.extras.indexOf('gradejewelcharm') !== -1) {
+        lines.push('// --- Jewel Grading ---');
+        lines.push('ItemDisplay[jew (MAG OR RARE) ID LIFE>14]: %RED%+%STAT7%Life %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[jew (MAG OR RARE) ID MANA>14]: %BLUE%+%STAT9%Mana %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[jew (MAG OR RARE) ID EDAM>29]: %RED%%EDAM%ED %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[jew (MAG OR RARE) ID STAT80>0]: %GREEN%%STAT80%MF %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[jew (MAG OR RARE) ID FCR>0]: %TAN%%STAT105%FCR %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[jew (MAG OR RARE) ID IAS>0]: %ORANGE%%STAT93%IAS %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[jew (MAG OR RARE) ID FHR>0]: %GOLD%%STAT99%FHR %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[jew (MAG OR RARE) ID FRW>0]: %GOLD%%STAT96%FRW %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[jew (MAG OR RARE) ID FBR>0]: %ORANGE%%STAT102%FBR %NAME%%CONTINUE%{%NAME%}');
+
+        lines.push('// --- Grand Charm Grading ---');
+        // Any +1 to a skill tab: OR across all class tab codes (no "any tab" shorthand in PD2 filter syntax)
+        var anyTab = '(TABSK0>0 OR TABSK1>0 OR TABSK2>0 OR TABSK8>0 OR TABSK9>0 OR TABSK10>0 OR TABSK16>0 OR TABSK17>0 OR TABSK18>0 OR TABSK24>0 OR TABSK25>0 OR TABSK26>0 OR TABSK32>0 OR TABSK33>0 OR TABSK34>0 OR TABSK40>0 OR TABSK41>0 OR TABSK42>0 OR TABSK48>0 OR TABSK49>0 OR TABSK50>0)';
+        lines.push('ItemDisplay[cm3 (MAG OR RARE) ID LIFE>34]: %RED%+%STAT7%Life %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm3 (MAG OR RARE) ID MANA>16]: %BLUE%+%STAT9%Mana %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm3 (MAG OR RARE) ID STAT80>24]: %GREEN%%STAT80%MF %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm3 (MAG OR RARE) ID RES>14]: %PURPLE%%RES%Res %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm3 (MAG OR RARE) ID FHR>9]: %GOLD%%STAT99%FHR %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm3 (MAG OR RARE) ID EDAM>0]: %RED%%EDAM%ED %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm3 (MAG OR RARE) ID ' + anyTab + ']: %PURPLE%+SkillTab %NAME%%CONTINUE%{%NAME%}');
+
+        lines.push('// --- Large Charm Grading ---');
+        lines.push('ItemDisplay[cm2 (MAG OR RARE) ID LIFE>29]: %RED%+%STAT7%Life %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm2 (MAG OR RARE) ID MANA>16]: %BLUE%+%STAT9%Mana %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm2 (MAG OR RARE) ID RES>14]: %PURPLE%%RES%Res %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm2 (MAG OR RARE) ID STAT80>14]: %GREEN%%STAT80%MF %NAME%%CONTINUE%{%NAME%}');
+
+        lines.push('// --- Small Charm Grading ---');
+        lines.push('ItemDisplay[cm1 (MAG OR RARE) ID LIFE>19]: %RED%+%STAT7%Life %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm1 (MAG OR RARE) ID MANA>9]: %BLUE%+%STAT9%Mana %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm1 (MAG OR RARE) ID RES>10]: %PURPLE%%RES%Res %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm1 (MAG OR RARE) ID STAT80>6]: %GREEN%%STAT80%MF %NAME%%CONTINUE%{%NAME%}');
+        lines.push('ItemDisplay[cm1 (MAG OR RARE) ID EDAM>0]: %RED%%EDAM%ED %NAME%%CONTINUE%{%NAME%}');
+      }
+
+      if (c.extras.indexOf('lowrollcharm') !== -1) {
+        lines.push('// --- Low-roll Charm Tag ---');
+        var notTab = '!TABSK0 !TABSK1 !TABSK2 !TABSK8 !TABSK9 !TABSK10 !TABSK16 !TABSK17 !TABSK18 !TABSK24 !TABSK25 !TABSK26 !TABSK32 !TABSK33 !TABSK34 !TABSK40 !TABSK41 !TABSK42 !TABSK48 !TABSK49 !TABSK50';
+        var notClsk = '!CLSK0 !CLSK1 !CLSK2 !CLSK3 !CLSK4 !CLSK5 !CLSK6';
+        lines.push('ItemDisplay[cm1 MAG ID ' + notClsk + ' !RES !LIFE !MANA !STAT80 !FHR !EDAM ' + notTab + ']: %GRAY%[bad] %NAME%');
+        lines.push('ItemDisplay[cm2 MAG ID ' + notClsk + ' !RES !LIFE !MANA !STAT80 !FHR !EDAM ' + notTab + ']: %GRAY%[bad] %NAME%');
+        lines.push('ItemDisplay[cm3 MAG ID ' + notClsk + ' !RES !LIFE !MANA !STAT80 !FHR !EDAM ' + notTab + ']: %GRAY%[bad] %NAME%');
+      }
       lines.push('');
 
       // ==========================


### PR DESCRIPTION
## Summary
Two opt-in extras toggles fill the post-ID jewel/charm highlighting gap reported in #172.

- **Grade Jewels & Charms** — positive grading for identified jewels and cm1/cm2/cm3 (life, mana, res, MF, FCR/IAS/FHR/FRW/FBR, EDAM where applicable, and +1 skill tab on GCs).
- **Tag low-roll charms** — gray \`[bad]\` label on identified magic cm1/cm2/cm3 that have no meaningful affix.

Closes #172

## Thresholds
- Jewels: LIFE>14 / MANA>14 / EDAM>29 / MF>0 / FCR/IAS/FHR/FRW/FBR>0.
- Grand charms: LIFE>34 / MANA>16 / MF>24 / RES>14 / FHR>9 / EDAM>0 / +1 skill tab >0 (CLSK already handled elsewhere).
- Large charms: LIFE>29 / MANA>16 / RES>14 / MF>14.
- Small charms: LIFE>19 / MANA>9 / RES>10 / MF>6 / EDAM>0.

## Test plan
- [ ] Generate filter with both toggles off — verify identified jewels/charms display unchanged.
- [ ] Toggle \"Grade Jewels & Charms\" on, regenerate — verify GG jewels (e.g. 15 IAS / 30 life) and high-roll charms light up.
- [ ] Toggle \"Tag low-roll charms\" on, regenerate — verify a +5 dex GC shows \`[bad]\`, while a +45 life GC does not.
- [ ] Both toggles on — verify positive and low-roll rules don't conflict (good rolls light up, junk gets \`[bad]\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)