### PR TITLE
Fix #191: update community filter list from Project-Diablo-2/LootFilters

### DIFF
--- a/data/filters.json
+++ b/data/filters.json
@@ -30,6 +30,21 @@
     "author": "HiimFilter"
   },
   {
+    "name": "HiimFilter - Hyper",
+    "url": "https://api.github.com/repos/Maaaaaarrk/HiimFilter-PD2-Filter/contents/filtergroups/hiimhyper",
+    "author": "Hiim - Hyper"
+  },
+  {
+    "name": "HiimFilter - TalRasha",
+    "url": "https://api.github.com/repos/Maaaaaarrk/HiimFilter-PD2-Filter/contents/filtergroups/hiimtalrasha",
+    "author": "Hiim - TalRasha"
+  },
+  {
+    "name": "HiimFilter - Vanilla+",
+    "url": "https://api.github.com/repos/Maaaaaarrk/HiimFilter-PD2-Filter/contents/filtergroups/hiimvanillaplus",
+    "author": "Hiim - Vanilla+"
+  },
+  {
     "name": "DarkHumility + ADev Filter",
     "url": "https://api.github.com/repos/DarkHumility/DHFilter/contents",
     "author": "ADevDH"
@@ -50,11 +65,6 @@
     "author": "PiLLLa"
   },
   {
-    "name": "Loot Goblin Filter",
-    "url": "https://api.github.com/repos/PreyInstinct/Loot-Goblin-Filter/contents",
-    "author": "PreyInstinct"
-  },
-  {
     "name": "Roofoo's Filter",
     "url": "https://api.github.com/repos/RoofooEvazan/Roofoo-s-PD2-Loot-Filter/contents",
     "author": "Roofoo"
@@ -63,5 +73,25 @@
     "name": "Phyx10n's Filter",
     "url": "https://api.github.com/repos/Phyx10n/PD2-Filter/contents",
     "author": "Phyx10n"
+  },
+  {
+    "name": "Vylens PD2 Filter",
+    "url": "https://api.github.com/repos/Vylens/Vylens-PD2-Filter/contents",
+    "author": "Vylens"
+  },
+  {
+    "name": "Kassahi & Philanthropy777 Filter",
+    "url": "https://api.github.com/repos/Maaaaaarrk/HiimFilter-PD2-Filter/contents/filtergroups/phil777",
+    "author": "Philanthropy777"
+  },
+  {
+    "name": "THE MATRIX ARCHITECT",
+    "url": "https://api.github.com/repos/huns1313/THE-MATRIX-ARCHITECT/contents",
+    "author": "huns1313"
+  },
+  {
+    "name": "Loot Goblin Filter",
+    "url": "https://api.github.com/repos/PreyInstinct/Loot-Goblin-Filter/contents",
+    "author": "PreyInstinct"
   }
 ]


### PR DESCRIPTION
Closes #191

Syncs `data/filters.json` (the local fallback for the community filter list) with the upstream source of truth at [Project-Diablo-2/LootFilters/filters.json](https://github.com/Project-Diablo-2/LootFilters/blob/main/filters.json). Schema (`{name, url, author}`) is identical, so this is a direct field-for-field reconcile.

**Added (6 new filters from upstream):**
- HiimFilter - Hyper (Hiim - Hyper)
- HiimFilter - TalRasha (Hiim - TalRasha)
- HiimFilter - Vanilla+ (Hiim - Vanilla+)
- Vylens PD2 Filter (Vylens)
- Kassahi & Philanthropy777 Filter (Philanthropy777)
- THE MATRIX ARCHITECT (huns1313)

**Preserved (FilterForge-specific, not in upstream):**
- Loot Goblin Filter (PreyInstinct) — repo is still live (last pushed Dec 2025, contains valid .filter files), so kept rather than removed.

**Removed:** none.

Result: 13 -> 19 entries.